### PR TITLE
Configuration parser help

### DIFF
--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -711,7 +711,7 @@ func help() {
 }
 
 func main() {
-	log2.SetLevel(log2.DebugLevel)
+	log2.SetLevel(log2.WarnLevel)
 
 	flag.Parse()
 	if *fhelp {

--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -36,6 +36,8 @@ import (
 	"strings"
 	"sync"
 
+	log2 "github.com/sirupsen/logrus"
+
 	"github.com/telenornms/skogul/config"
 	"github.com/telenornms/skogul/receiver"
 	"github.com/telenornms/skogul/sender"
@@ -709,6 +711,8 @@ func help() {
 }
 
 func main() {
+	log2.SetLevel(log2.DebugLevel)
+
 	flag.Parse()
 	if *fhelp {
 		help()
@@ -733,6 +737,7 @@ func main() {
 		fmt.Println(string(out))
 		os.Exit(0)
 	}
+	log2.Info("Starting skogul")
 
 	var exitInt = 0
 	var wg sync.WaitGroup

--- a/config/parse.go
+++ b/config/parse.go
@@ -196,7 +196,7 @@ func Bytes(b []byte) (*Config, error) {
 
 	c := Config{}
 	if err := json.Unmarshal(b, &c); err != nil {
-		log.WithError(err).Fatal("The JSON configuration is improperly formatted JSON")
+		log.WithError(err).Fatal("Failed to unmarshal the configuration into Skogul.")
 		return nil, skogul.Error{Source: "config parser", Reason: "Unable to parse JSON config", Next: err}
 	}
 

--- a/config/parse.go
+++ b/config/parse.go
@@ -361,11 +361,13 @@ func getRelevantRawConfigSection(rawConfig *map[string]interface{}, family, sect
 	return (*rawConfig)[family].(map[string]interface{})[strings.ToLower(section)].(map[string]interface{})
 }
 
-func verifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family, handler string, T reflect.Type) {
+func verifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family, handler string, T reflect.Type) []string {
 	requiredProps := findFieldsOfStruct(T)
 	log.Debugf("Required fields: %v", requiredProps)
 
 	relevantConfig := getRelevantRawConfigSection(rawConfig, family, handler)
+
+	superfluousProperties := make([]string, 0)
 
 	for prop := range relevantConfig {
 		propertyDefined := false
@@ -382,7 +384,10 @@ func verifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family, ha
 			}
 		}
 		if !propertyDefined {
+			superfluousProperties = append(superfluousProperties, prop)
 			log.WithField("property", prop).Warn("Configuration property configured but not defined in code (this property won't change anything, is it wrongly defined?)")
 		}
 	}
+
+	return superfluousProperties
 }

--- a/config/parse.go
+++ b/config/parse.go
@@ -31,6 +31,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/telenornms/skogul"
 	"github.com/telenornms/skogul/parser"
 	"github.com/telenornms/skogul/receiver"
@@ -186,6 +188,7 @@ func (s *Sender) UnmarshalJSON(b []byte) error {
 func Bytes(b []byte) (*Config, error) {
 	c := Config{}
 	if err := json.Unmarshal(b, &c); err != nil {
+		log.WithError(err).Fatal("The JSON configuration is improperly formatted JSON")
 		return nil, skogul.Error{Source: "config parser", Reason: "Unable to parse JSON config", Next: err}
 	}
 
@@ -197,6 +200,7 @@ func Bytes(b []byte) (*Config, error) {
 func File(f string) (*Config, error) {
 	dat, err := ioutil.ReadFile(f)
 	if err != nil {
+		log.WithError(err).Fatal("Failed to read config file")
 		return nil, skogul.Error{Source: "config parser", Reason: "Failed to read config file", Next: err}
 	}
 	return Bytes(dat)

--- a/config/parse.go
+++ b/config/parse.go
@@ -420,7 +420,7 @@ func verifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family, ha
 			}
 		}
 		if !propertyDefined {
-			log.WithField("property", prop).Warn("Property configured but not defined in code (this property won't change anything, is it wrongly defined?)")
+			log.WithField("property", prop).Warn("Configuration property configured but not defined in code (this property won't change anything, is it wrongly defined?)")
 		}
 	}
 }

--- a/config/parse.go
+++ b/config/parse.go
@@ -330,7 +330,7 @@ func verifyItem(family string, name string, item interface{}) error {
 }
 
 func findFieldsOfStruct(T reflect.Type) []string {
-	log.WithField("type", T.Name()).Debug("Finding required fields for type")
+	log.WithField("type", T.Name()).Debug("Finding defined fields for type")
 	requiredProps := make([]string, 0)
 	switch T.Kind() {
 	case reflect.Struct:
@@ -382,16 +382,11 @@ func verifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family str
 		propertyDefined := false
 
 		if prop == "type" {
-			// @ToDo: Should we define the type internally?
+			// Skip the type specifying what type this is
 			continue
 		}
 
 		for _, requiredProp := range requiredProps {
-			// log.WithFields(log.Fields{
-			// 	"prop":    prop,
-			// 	"reqProp": requiredProp,
-			// 	"equal":   prop == requiredProp,
-			// }).Debug("Comparing")
 			if strings.ToLower(prop) == strings.ToLower(requiredProp) {
 				propertyDefined = true
 				break

--- a/config/parse.go
+++ b/config/parse.go
@@ -294,12 +294,20 @@ func secondPass(c *Config, jsonData *map[string]interface{}) (*Config, error) {
 		if err := verifyItem("handler", idx, h.Handler); err != nil {
 			return nil, err
 		}
+
+		configStruct := reflect.TypeOf(h.Handler)
+		_ = findMissingRequiredConfigProps(jsonData, "handlers", idx, configStruct)
+		verifyOnlyRequiredConfigProps(jsonData, "handlers", idx, configStruct)
 	}
 	for idx, s := range c.Senders {
 		log.WithField("sender", idx).Debug("Verifying sender configuration")
 		if err := verifyItem("sender", idx, s.Sender); err != nil {
 			return nil, err
 		}
+
+		configStruct := reflect.ValueOf(s.Sender).Elem().Type()
+		_ = findMissingRequiredConfigProps(jsonData, "senders", idx, configStruct)
+		verifyOnlyRequiredConfigProps(jsonData, "senders", idx, configStruct)
 	}
 	for idx, r := range c.Receivers {
 		log.WithField("receiver", idx).Debug("Verifying receiver configuration")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/protobuf v1.3.1
 	github.com/lib/pq v1.2.0
+	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	google.golang.org/appengine v1.6.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
@@ -6,10 +7,16 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/lib/pq v1.1.0 h1:/5u4a+KGJptBRqGzPvYQL9p0d/tPR4S31+Tnzj9lEO4=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -23,6 +30,8 @@ golang.org/x/net v0.0.0-20190926025831-c00fd9afed17/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606165138-5da285871e9c h1:+EXw7AwNOKzPFXMZ1yNjO40aWCh3PIquJB2fYlv9wcs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/receiver/http.go
+++ b/receiver/http.go
@@ -139,9 +139,7 @@ func (htt *HTTP) Start() error {
 		}).Debug("Adding handler")
 		serveMux.Handle(idx, receiver{Handler: h.H, settings: htt})
 	}
-	if htt.Address == "" {
-		log.Printf("HTTP: No listen-address specified. Using go default (probably :http or :https?)")
-	}
+
 	server.Addr = htt.Address
 	if htt.Certfile != "" {
 		log.WithField("address", htt.Address).Info("Starting http receiver with TLS")
@@ -153,10 +151,16 @@ func (htt *HTTP) Start() error {
 	return skogul.Error{Reason: "Shouldn't reach this"}
 }
 
-// Verify ensures at least one handler exists for the HTTP receiver.
+// Verify verifies the configuration for the HTTP receiver
 func (htt *HTTP) Verify() error {
 	if htt.Handlers == nil || len(htt.Handlers) == 0 {
+		log.Error("No handlers specified. Need at least one.")
 		return skogul.Error{Source: "http receiver", Reason: "No handlers specified. Need at least one."}
 	}
+
+	if htt.Address == "" {
+		log.Warn("Missing listen address for http receiver, using Go default")
+	}
+
 	return nil
 }

--- a/receiver/http.go
+++ b/receiver/http.go
@@ -145,7 +145,7 @@ func (htt *HTTP) Start() error {
 		log.WithField("address", htt.Address).Info("Starting http receiver with TLS")
 		log.Fatal(server.ListenAndServeTLS(htt.Certfile, htt.Keyfile))
 	} else {
-		log.WithField("address", htt.Address).Debug("Starting INSECURE http receiver (no TLS)")
+		log.WithField("address", htt.Address).Info("Starting INSECURE http receiver (no TLS)")
 		log.Fatal(server.ListenAndServe())
 	}
 	return skogul.Error{Reason: "Shouldn't reach this"}

--- a/receiver/http.go
+++ b/receiver/http.go
@@ -27,8 +27,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/telenornms/skogul"
 )
@@ -85,7 +86,11 @@ func (rcvr receiver) handle(w http.ResponseWriter, r *http.Request) (int, error)
 	b := make([]byte, r.ContentLength)
 
 	if n, err := io.ReadFull(r.Body, b); err != nil {
-		log.Printf("Read error from client %v, read %d bytes: %s", r.RemoteAddr, n, err)
+		log.WithFields(log.Fields{
+			"address":  r.RemoteAddr,
+			"error":    err,
+			"numbytes": n,
+		}).Error("Read error from client")
 		return 400, skogul.Error{Source: "http receiver", Reason: "read failed", Next: err}
 	}
 
@@ -116,7 +121,7 @@ func (htt *HTTP) Start() error {
 	serveMux := http.NewServeMux()
 	server.Handler = serveMux
 	if htt.Username != "" {
-		log.Printf("Enforcing basic authentication for user `%s'", htt.Username)
+		log.WithField("username", htt.Username).Debug("Enforcing basic authentication")
 		if htt.Password == "" {
 			log.Fatal("HTTP receiver has a Username provided, but not a password? Probably a mistake.")
 		}
@@ -128,7 +133,10 @@ func (htt *HTTP) Start() error {
 		htt.auth = false
 	}
 	for idx, h := range htt.Handlers {
-		log.Printf("Adding handler %v -> %v", idx, h.Name)
+		log.WithFields(log.Fields{
+			"configuredHandler": idx,
+			"selectedHandler":   h.Name,
+		}).Debug("Adding handler")
 		serveMux.Handle(idx, receiver{Handler: h.H, settings: htt})
 	}
 	if htt.Address == "" {
@@ -136,10 +144,10 @@ func (htt *HTTP) Start() error {
 	}
 	server.Addr = htt.Address
 	if htt.Certfile != "" {
-		log.Printf("Starting http receiver with TLS at %s", htt.Address)
+		log.WithField("address", htt.Address).Info("Starting http receiver with TLS")
 		log.Fatal(server.ListenAndServeTLS(htt.Certfile, htt.Keyfile))
 	} else {
-		log.Printf("Starting INSECURE http receiver (no TLS) at %s", htt.Address)
+		log.WithField("address", htt.Address).Debug("Starting INSECURE http receiver (no TLS)")
 		log.Fatal(server.ListenAndServe())
 	}
 	return skogul.Error{Reason: "Shouldn't reach this"}


### PR DESCRIPTION
This feature aims to resolve #19 by using reflection on the senders, receivers and handlers to identify their properties. During startup, all properties are automatically parsed by Go if everything is configured properly. However, this adds a routine to run during initialization to verify the specified configuration parameters with regards to superfluous fields (which in theory could be mistyped configuration parameters).

Dependencies:

* Adds sirupsen/logrus as a logging framework and uses this throughout the feature. 

Examples:

```json
{
  "receivers": {
    "bar": {
      "type": "udp",
      "address": "[::1]:5015",
      "superfluousField": "sure thing",
      "handler": "protobuf"
    }
  }
}
```

In this configuration there is an excess field. This could be a mistyped field, which potentially could change how things work (especially if it is an optional field), and it will produce a warning, which is shown in the following output:

```
WARN[0000] Configuration property configured but not defined in code (this property won't change anything, is it wrongly defined?)  property=superfluousField
```