### PR TITLE
feat: Generate protobuf go files during go generate

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -1,0 +1,3 @@
+package skogul
+
+//go:generate /bin/bash -c "prototool generate || echo '❌ Could not generate go files from prototcol buffer definitions'"


### PR DESCRIPTION
Resolves #34 to generate go files from the protobuf definitions. This PR does not include the protobuf sources for the currently generated files as per the question in a comment in #34.