### PR TITLE
Update prototool config to work for new Juniper proto definitions

### DIFF
--- a/prototool.yaml
+++ b/prototool.yaml
@@ -1,3 +1,11 @@
+excludes:
+  # Extension number 44 has already been used in "JuniperNetworksSensors" by extension "jnpr_junos_l2tp_ext" defined in jl2tpd_oc.proto.
+  - ./gen/junos-telemetry-interface/jl2tpd_oc.proto
+  - ./gen/junos-telemetry-interface/sr_te_transit_tunnel_stats.proto
+  # Extension number 45 has already been used in "JuniperNetworksSensors" by extension "jnpr_junos_ppp_ext" defined in jpppd_oc.proto
+  - ./gen/junos-telemetry-interface/jpppd_oc.proto
+  - ./gen/junos-telemetry-interface/sr_te_ingress_tunnel_stats.proto
+
 protoc:
   version: 3.8.0
   includes:

--- a/prototool.yaml
+++ b/prototool.yaml
@@ -1,11 +1,13 @@
 protoc:
   version: 3.8.0
   includes:
-    - ./gen/junos-telemetry-interface
+    - ./gen/junos-telemetry-interface/
+
 create:
   packages:
     - directory: gen
       name: gen
+
 generate:
   go_options:
     import_path: .

--- a/prototool.yaml
+++ b/prototool.yaml
@@ -24,4 +24,5 @@ generate:
     - name: go
       type: go
       output: ./gen
+      # Available parameters/flags are listed here: https://github.com/golang/protobuf#parameters
       flags: import_path=gen

--- a/prototool.yaml
+++ b/prototool.yaml
@@ -24,3 +24,4 @@ generate:
     - name: go
       type: go
       output: ./gen
+      flags: import_path=gen


### PR DESCRIPTION
* Excludes the protobuf definitions which has colliding extension numbers
* Update the path to where the protobuf definitions are