### PR TITLE
Feature/issue 38 transform content of metrics

### DIFF
--- a/config/parse.go
+++ b/config/parse.go
@@ -347,6 +347,15 @@ func secondPass(c *Config, jsonData *map[string]interface{}) (*Config, error) {
 		configStruct := reflect.TypeOf(h.Handler)
 		verifyOnlyRequiredConfigProps(jsonData, "handlers", idx, configStruct)
 	}
+	for idx, t := range c.Transformers {
+		log.WithField("transformer", idx).Debug("Verifying transformer configuration")
+		if err := verifyItem("transformer", idx, t.Transformer); err != nil {
+			return nil, err
+		}
+
+		configStruct := reflect.ValueOf(t.Transformer).Elem().Type()
+		verifyOnlyRequiredConfigProps(jsonData, "transformers", idx, configStruct)
+	}
 	for idx, s := range c.Senders {
 		log.WithField("sender", idx).Debug("Verifying sender configuration")
 		if err := verifyItem("sender", idx, s.Sender); err != nil {

--- a/skogul.1
+++ b/skogul.1
@@ -708,6 +708,25 @@ Require the pressence of these fields.
 .B \fBset \- map[string]interface {}\fP
 Set metadata fields to specific values.
 .UNINDENT
+.SS replace
+.sp
+Uses a regular expression to replace the content of a metadata key, storing it to either a different metadata key, or overwriting the original.
+.sp
+Settings:
+.INDENT 0.0
+.TP
+.B \fBdestination \- string\fP
+Metadata key to write to. Defaults to overwriting the source\-key if left blank. Destination key will always be overwritten, e.g., even if the source key is missing, the key located at the destination will be removed.
+.TP
+.B \fBregex \- string\fP
+Regular expression to match.
+.TP
+.B \fBreplacement \- string\fP
+Replacement text. Can also use $1, $2, etc to reference sub\-matches. Defaults to empty string \- remove matching items.
+.TP
+.B \fBsource \- string\fP
+Metadata key to read from.
+.UNINDENT
 .SS split
 .sp
 Splits a metric into multiple metrics based on a field.

--- a/skogul.rst
+++ b/skogul.rst
@@ -690,6 +690,25 @@ Settings:
 ``set - map[string]interface {}``
 	Set metadata fields to specific values.
 
+replace
+-------
+
+Uses a regular expression to replace the content of a metadata key, storing it to either a different metadata key, or overwriting the original.
+
+Settings:
+
+``destination - string``
+	Metadata key to write to. Defaults to overwriting the source-key if left blank. Destination key will always be overwritten, e.g., even if the source key is missing, the key located at the destination will be removed.
+
+``regex - string``
+	Regular expression to match.
+
+``replacement - string``
+	Replacement text. Can also use $1, $2, etc to reference sub-matches. Defaults to empty string - remove matching items.
+
+``source - string``
+	Metadata key to read from.
+
 split
 -----
 

--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -57,4 +57,10 @@ func init() {
 		Alloc:   func() skogul.Transformer { return &Split{} },
 		Help:    "Splits a metric into multiple metrics based on a field.",
 	})
+	Add(Transformer{
+		Name:    "replace",
+		Aliases: []string{},
+		Alloc:   func() skogul.Transformer { return &Replace{} },
+		Help:    "Uses a regular expression to replace the content of a metadata key, storing it to either a different metadata key, or overwriting the original.",
+	})
 }

--- a/transformer/edit.go
+++ b/transformer/edit.go
@@ -32,7 +32,7 @@ import (
 	"github.com/telenornms/skogul"
 )
 
-// Replace executes a set of regular expressions, in order
+// Replace executes a regular expression replacement of metric metadata.
 type Replace struct {
 	Source      string `doc:"Metadata key to read from."`
 	Destination string `doc:"Metadata key to write to. Defaults to overwriting the source-key if left blank. Destination key will always be overwritten, e.g., even if the source key is missing, the key located at the destination will be removed."`
@@ -54,7 +54,8 @@ func (replace *Replace) Transform(c *skogul.Container) error {
 	// Verify() should catch this, so there's no reasonable way this
 	// should happen. But in the off chance that a regex compiles on
 	// the first attempt but not the second.... (e.g.: some serious
-	// bugs)
+	// bugs). It will also catch our own bugs, if, for some reason, we
+	// manage to botch up Verify() under some corner case.
 	skogul.Assert(replace.err == nil)
 
 	for mi := range c.Metrics {

--- a/transformer/edit.go
+++ b/transformer/edit.go
@@ -1,0 +1,68 @@
+/*
+ * skogul, edit transformer
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package transformer
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"sync"
+
+	"github.com/telenornms/skogul"
+)
+
+// Replace executes a set of regular expressions, in order
+type Replace struct {
+	Source      string `doc:"Metadata key to read from."`
+	Destination string `doc:"Metadata key to write to."`
+	Regex       string `doc:"Regular expression to match."`
+	Replacement string `doc:"Replacement text. Can also use $1, $2, etc to reference sub-matches."`
+	regex       *regexp.Regexp
+	once        sync.Once
+	err         error // Used to signal persistent error - e.g., if the regular expression didn't compile.
+}
+
+// Transform executes the regular expression replacement
+func (replace *Replace) Transform(c *skogul.Container) error {
+	replace.once.Do(func() {
+		replace.regex, replace.err = regexp.Compile(replace.Regex)
+	})
+	if replace.err != nil {
+		return skogul.Error{Source: "replace transformer", Reason: fmt.Sprintf("Failed to compile regular expression: %s", replace.err)}
+	}
+
+	for mi := range c.Metrics {
+		if c.Metrics[mi].Metadata == nil || c.Metrics[mi].Metadata[replace.Source] == nil {
+			continue
+		}
+		str, ok := c.Metrics[mi].Metadata[replace.Source].(string)
+		if !ok {
+			// FIXME: What to do?
+			log.Printf("Unable to transform non-string field %s with content %v", replace.Source, c.Metrics[mi].Metadata[replace.Source])
+			continue
+		}
+		c.Metrics[mi].Metadata[replace.Destination] = string(replace.regex.ReplaceAll([]byte(str), []byte(replace.Replacement)))
+	}
+	return nil
+}

--- a/transformer/edit.go
+++ b/transformer/edit.go
@@ -35,34 +35,70 @@ import (
 // Replace executes a set of regular expressions, in order
 type Replace struct {
 	Source      string `doc:"Metadata key to read from."`
-	Destination string `doc:"Metadata key to write to."`
+	Destination string `doc:"Metadata key to write to. Defaults to overwriting the source-key if left blank. Destination key will always be overwritten, e.g., even if the source key is missing, the key located at the destination will be removed."`
 	Regex       string `doc:"Regular expression to match."`
-	Replacement string `doc:"Replacement text. Can also use $1, $2, etc to reference sub-matches."`
+	Replacement string `doc:"Replacement text. Can also use $1, $2, etc to reference sub-matches. Defaults to empty string - remove matching items."`
 	regex       *regexp.Regexp
 	once        sync.Once
-	err         error // Used to signal persistent error - e.g., if the regular expression didn't compile.
+	err         error
 }
 
 // Transform executes the regular expression replacement
 func (replace *Replace) Transform(c *skogul.Container) error {
 	replace.once.Do(func() {
+		if replace.Destination == "" {
+			replace.Destination = replace.Source
+		}
 		replace.regex, replace.err = regexp.Compile(replace.Regex)
 	})
-	if replace.err != nil {
-		return skogul.Error{Source: "replace transformer", Reason: fmt.Sprintf("Failed to compile regular expression: %s", replace.err)}
-	}
+	// Verify() should catch this, so there's no reasonable way this
+	// should happen. But in the off chance that a regex compiles on
+	// the first attempt but not the second.... (e.g.: some serious
+	// bugs)
+	skogul.Assert(replace.err == nil)
 
 	for mi := range c.Metrics {
-		if c.Metrics[mi].Metadata == nil || c.Metrics[mi].Metadata[replace.Source] == nil {
+		if c.Metrics[mi].Metadata == nil {
+			continue
+		}
+		if c.Metrics[mi].Metadata[replace.Source] == nil {
+			delete(c.Metrics[mi].Metadata, replace.Destination)
 			continue
 		}
 		str, ok := c.Metrics[mi].Metadata[replace.Source].(string)
 		if !ok {
-			// FIXME: What to do?
+			// FIXME: What to do? It's tempting to copy the
+			// key, but that could mean multiple references to
+			// the same memory, which can create unexpected
+			// behavior if other transformers want to modify
+			// just one of the headers.
 			log.Printf("Unable to transform non-string field %s with content %v", replace.Source, c.Metrics[mi].Metadata[replace.Source])
+			// This is to confirm with the documentation and
+			// ensure that this isn't exploited by providing a
+			// bogus Source-field only to be able to provide a
+			// custom destination field.
+			delete(c.Metrics[mi].Metadata, replace.Destination)
 			continue
 		}
 		c.Metrics[mi].Metadata[replace.Destination] = string(replace.regex.ReplaceAll([]byte(str), []byte(replace.Replacement)))
 	}
+	return nil
+}
+
+// Verify checks that the required variables are set and that the regular
+// expression compiles
+func (replace *Replace) Verify() error {
+	if replace.Source == "" {
+		return skogul.Error{Source: "replace transformer", Reason: "Missing Source field in configuration"}
+	}
+	if replace.Regex == "" {
+		return skogul.Error{Source: "replace transformer", Reason: "Missing Regex field in configuration"}
+	}
+	regex, err := regexp.Compile(replace.Regex)
+
+	if err != nil {
+		return skogul.Error{Source: "replace transformer", Reason: fmt.Sprintf("Regex didn't compile: %s", err)}
+	}
+	skogul.Assert(regex != nil)
 	return nil
 }

--- a/transformer/edit_test.go
+++ b/transformer/edit_test.go
@@ -1,0 +1,63 @@
+/*
+ * skogul, edit transformer tests
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package transformer_test
+
+import (
+	"testing"
+
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/transformer"
+)
+
+func checkReplace(t *testing.T, m *skogul.Metric, field string, want interface{}) {
+	t.Helper()
+	if m.Metadata[field] != want {
+		t.Errorf("Edit transformer failed to enforce rule for field \"%s\". Wanted \"%v\", got \"%v\"", field, want, m.Metadata[field])
+	}
+}
+
+func TestReplace(t *testing.T) {
+	metric := skogul.Metric{}
+	metric.Metadata = make(map[string]interface{})
+	metric.Metadata["foo"] = "original"
+	c := skogul.Container{}
+	c.Metrics = []*skogul.Metric{&metric}
+
+	replace := transformer.Replace{
+		Source:      "foo",
+		Destination: "bar",
+		Regex:       "igi",
+		Replacement: "KJELL MAGNE BONDEVIK MED SMÅ BOKSTAVER UTEN MELLOMNAVN",
+	}
+
+	t.Logf("Container before transform:\n%v", c)
+	err := replace.Transform(&c)
+	if err != nil {
+		t.Errorf("Metadata() returned non-nil err: %v", err)
+	}
+	t.Logf("Container after transform:\n%v", c)
+
+	checkReplace(t, c.Metrics[0], "foo", "original")
+	checkReplace(t, c.Metrics[0], "bar", "orKJELL MAGNE BONDEVIK MED SMÅ BOKSTAVER UTEN MELLOMNAVNnal")
+}

--- a/transformer/metadata_test.go
+++ b/transformer/metadata_test.go
@@ -112,7 +112,7 @@ func TestMetadata_config(t *testing.T) {
 	}`)
 }
 
-func testConfOk(t *testing.T, rawconf string) {
+func testConfOk(t *testing.T, rawconf string) *config.Config {
 	t.Helper()
 	conf, err := config.Bytes([]byte(rawconf))
 	if err != nil {
@@ -121,6 +121,7 @@ func testConfOk(t *testing.T, rawconf string) {
 	if conf == nil {
 		t.Errorf("failed to get valid config for transformer")
 	}
+	return conf
 }
 
 func testConfBad(t *testing.T, rawconf string) {


### PR DESCRIPTION
This should cover most of what #38 is really about. The corner-case of non-string'able source fields isn't perfect, but I don't really see any valid way of handling this.