### PR TITLE
Introduce skogul.Logger() and use it

### DIFF
--- a/common.go
+++ b/common.go
@@ -25,6 +25,7 @@ package skogul
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"runtime"
 	"time"
 )
@@ -221,6 +222,14 @@ func (h Handler) Verify() error {
 		return Error{Reason: "Missing parser for Handler"}
 	}
 	return nil
+}
+
+// Logger returns a logrus.Entry pre-populated with standard Skogul fields.
+// sourceType is the typical family of the code/module:
+// sender/receiver/parser/transformer/core, while sourceName is the local
+// implementation.
+func Logger(sourceType, sourceName string) *logrus.Entry {
+	return logrus.WithField("source", sourceType).WithField(sourceType, sourceName)
 }
 
 // AssertErrors counts the number of assert errors

--- a/data.go
+++ b/data.go
@@ -27,9 +27,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
+
+var dataLog = Logger("core", "data")
 
 /*
 Container is the top-level object for one or more metric.
@@ -187,7 +187,7 @@ func (c *Container) Validate() error {
 func (c Container) String() string {
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		log.WithError(err).Error("Unable to marshal JSON")
+		dataLog.WithError(err).Error("Unable to marshal JSON")
 		return ""
 	}
 	return fmt.Sprintf("%s", b)

--- a/receiver/linefile.go
+++ b/receiver/linefile.go
@@ -28,10 +28,10 @@ import (
 	"os"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var lfLog = skogul.Logger("receiver", "linefile")
 
 // LineFile will keep reading File over and over again, assuming one
 // collection per line. Best suited for pointing at a FIFO, which will
@@ -46,18 +46,18 @@ type LineFile struct {
 func (lf *LineFile) read() error {
 	f, err := os.Open(lf.File)
 	if err != nil {
-		log.WithError(err).WithField("file", lf.File).Error("Unable to open file")
+		lfLog.WithError(err).WithField("file", lf.File).Error("Unable to open file")
 		return err
 	}
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		bytes := scanner.Bytes()
 		if err := lf.Handler.H.Handle(bytes); err != nil {
-			log.WithError(err).Error("Failed to send metric")
+			lfLog.WithError(err).Error("Failed to send metric")
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		log.WithError(err).Error("Error reading file")
+		lfLog.WithError(err).Error("Error reading file")
 		return skogul.Error{Reason: "Error reading file"}
 	}
 	return nil

--- a/receiver/mqtt.go
+++ b/receiver/mqtt.go
@@ -30,8 +30,9 @@ import (
 	skmqtt "github.com/telenornms/skogul/internal/mqtt"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
-	log "github.com/sirupsen/logrus"
 )
+
+var mqttLog = skogul.Logger("receiver", "mqtt")
 
 /*
 MQTT connects to a MQTT broker and listens for messages on a topic.
@@ -49,7 +50,7 @@ type MQTT struct {
 func (handler *MQTT) receiver(msg mqtt.Message) {
 	err := handler.Handler.H.Handle(msg.Payload())
 	if err != nil {
-		log.WithError(err).Error("Unable to handle payload")
+		mqttLog.WithError(err).Error("Unable to handle payload")
 	}
 }
 
@@ -60,7 +61,7 @@ func (handler *MQTT) Start() error {
 	handler.mc.Password = handler.Password
 	handler.mc.Init()
 	handler.mc.Subscribe(handler.mc.Topic, handler.receiver)
-	log.WithField("address", handler.Address).Debug("Starting MQTT receiver")
+	mqttLog.WithField("address", handler.Address).Debug("Starting MQTT receiver")
 	handler.mc.Connect()
 	// Note that handler.listen() DOES return, because it only sets up
 	// subscriptions. This sillyness is to satisfy the requirement that

--- a/receiver/tcpline.go
+++ b/receiver/tcpline.go
@@ -28,10 +28,10 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var tcpLog = skogul.Logger("receiver", "tcp")
 
 /*
 TCPLine listens on a IP:TCP port specified in the Address string and accepts
@@ -70,7 +70,7 @@ func (tl *TCPLine) Start() error {
 	for {
 		conn, err := ln.AcceptTCP()
 		if err != nil {
-			log.WithError(err).Error("Unable to accept connection")
+			tcpLog.WithError(err).Error("Unable to accept connection")
 			continue
 		}
 		go tl.handleConnection(conn)
@@ -84,11 +84,11 @@ func (tl *TCPLine) handleConnection(conn *net.TCPConn) error {
 	for scanner.Scan() {
 		bytes := scanner.Bytes()
 		if err := tl.Handler.H.Handle(bytes); err != nil {
-			log.WithError(err).Error("Unable to parse JSON")
+			tcpLog.WithError(err).Error("Unable to parse JSON")
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		log.WithError(err).Error("Error reading line")
+		tcpLog.WithError(err).Error("Error reading line")
 		return skogul.Error{Reason: "Error reading file"}
 	}
 	return nil

--- a/receiver/tester.go
+++ b/receiver/tester.go
@@ -29,10 +29,10 @@ import (
 	"runtime"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var testerLog = skogul.Logger("receiver", "tester")
 
 // Tester synthesise dummy data.
 type Tester struct {
@@ -65,15 +65,15 @@ func (tst *Tester) generate(t time.Time) skogul.Container {
 func (tst *Tester) Start() error {
 	if tst.Threads == 0 {
 		tst.Threads = runtime.NumCPU()
-		log.WithField("threads", tst.Threads).Debug("No threads set, defaulting to runtime.NumCPU()")
+		testerLog.WithField("threads", tst.Threads).Debug("No threads set, defaulting to runtime.NumCPU()")
 	}
 	if tst.Metrics < 1 {
 		tst.Metrics = 10
-		log.WithField("metrics", tst.Metrics).Debug("No Metrics specified for testing, defaulting to default value")
+		testerLog.WithField("metrics", tst.Metrics).Debug("No Metrics specified for testing, defaulting to default value")
 	}
 	if tst.Values < 1 {
 		tst.Values = 50
-		log.WithField("values", tst.Values).Debug("No Values specified for testing, defaulting to default value")
+		testerLog.WithField("values", tst.Values).Debug("No Values specified for testing, defaulting to default value")
 	}
 	for i := 1; i < tst.Threads; i++ {
 		go tst.run()
@@ -87,7 +87,7 @@ func (tst *Tester) run() {
 	for {
 		c := tst.generate(time.Now())
 		if err := tst.Handler.H.TransformAndSend(&c); err != nil {
-			log.WithError(err).Error("Failed to transform and send metrics: %v", err)
+			testerLog.WithError(err).Errorf("Failed to transform and send metrics: %v", err)
 		}
 		time.Sleep(tst.Delay.Duration)
 	}

--- a/receiver/udp.go
+++ b/receiver/udp.go
@@ -26,10 +26,10 @@ package receiver
 import (
 	"net"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var udpLog = skogul.Logger("receiver", "udp")
 
 // UDP contains the configuration for the receiver
 type UDP struct {
@@ -41,24 +41,24 @@ type UDP struct {
 func (ud *UDP) Start() error {
 	udpip, err := net.ResolveUDPAddr("udp", ud.Address)
 	if err != nil {
-		log.WithError(err).WithField("address", ud.Address).Error("Can't resolve address")
+		udpLog.WithError(err).WithField("address", ud.Address).Error("Can't resolve address")
 		return err
 	}
 	ln, err := net.ListenUDP("udp", udpip)
 	if err != nil {
-		log.WithError(err).WithField("address", ud.Address).Error("Can't listen on address")
+		udpLog.WithError(err).WithField("address", ud.Address).Error("Can't listen on address")
 		return err
 	}
 	for {
 		bytes := make([]byte, 9000)
 		n, err := ln.Read(bytes)
 		if err != nil || n == 0 {
-			log.WithError(err).WithField("bytes", n).Error("Unable to read UDP message")
+			udpLog.WithError(err).WithField("bytes", n).Error("Unable to read UDP message")
 			continue
 		}
 		go func() {
 			if err := ud.Handler.H.Handle(bytes[0:n]); err != nil {
-				log.WithError(err).Error("Unable to handle UDP message")
+				udpLog.WithError(err).Error("Unable to handle UDP message")
 			}
 		}()
 	}

--- a/sender/batch.go
+++ b/sender/batch.go
@@ -29,10 +29,10 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var batchLog = skogul.Logger("sender", "batch")
 
 /*
 Batch sender collects metrics into a single container then passes them on
@@ -112,7 +112,7 @@ func (bat *Batch) add(c *skogul.Container) {
 		// It's allowed to exceed Threshold - but only once.
 		if newlen < nl {
 			newlen = nl
-			log.Warning((skogul.Error{Source: "batch sender", Reason: fmt.Sprintf("Warning: slice too small for 50%% slack - need to resize/copy. Performance hit :D(Default alloc size is %d, need %d)", bat.allocSize, newlen)}))
+			batchLog.Warning((skogul.Error{Source: "batch sender", Reason: fmt.Sprintf("Warning: slice too small for 50%% slack - need to resize/copy. Performance hit :D(Default alloc size is %d, need %d)", bat.allocSize, newlen)}))
 		}
 		x := make([]*skogul.Metric, newlen)
 		copy(x, bat.cont.Metrics)
@@ -130,7 +130,7 @@ func (bat *Batch) flusher() {
 		c := <-bat.out
 		err := bat.Next.S.Send(c)
 		if err != nil {
-			log.WithError(err).Error(skogul.Error{Source: "batch sender", Reason: "down stream error", Next: err})
+			batchLog.WithError(err).Error(skogul.Error{Source: "batch sender", Reason: "down stream error", Next: err})
 		}
 	}
 }

--- a/sender/counter.go
+++ b/sender/counter.go
@@ -27,10 +27,10 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var countLog = skogul.Logger("sender", "count")
 
 /*
 Counter sender emits, periodically, the flow-rate of metrics through
@@ -62,7 +62,7 @@ func (co *Counter) init() {
 	co.ch = make(chan count, 100)
 	co.up = true
 	if co.Period.Duration == 0 {
-		log.Debug("No Period set for Counter-sender. Using 1 second intervals.")
+		countLog.Debug("No Period set for Counter-sender. Using 1 second intervals.")
 		co.Period.Duration = 1 * time.Second
 	}
 	go co.getIt()
@@ -128,7 +128,7 @@ func (co *Counter) getIt() {
 			container.Metrics[0].Data["rate_metrics"] = rate.metrics
 			container.Metrics[0].Data["rate_values"] = rate.values
 			if err := co.Stats.H.TransformAndSend(&container); err != nil {
-				log.WithError(err).Error("Unable to transform and send counter stats")
+				countLog.WithError(err).Error("Unable to transform and send counter stats")
 			}
 			current = count{nil, 0, 0, 0}
 			last = *m.ts

--- a/sender/debug.go
+++ b/sender/debug.go
@@ -30,10 +30,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var debugLog = skogul.Logger("sender", "debug")
 
 /*
 Debug sender simply prints the metrics in json-marshalled format to
@@ -47,7 +47,7 @@ type Debug struct {
 func (db *Debug) Send(c *skogul.Container) error {
 	b, err := json.MarshalIndent(*c, "", "  ")
 	if err != nil {
-		log.WithError(err).Panic("Unable to marshal json for debug output")
+		debugLog.WithError(err).Panic("Unable to marshal json for debug output")
 		return err
 	}
 	fmt.Printf("%s%s\n", db.Prefix, b)
@@ -72,7 +72,7 @@ type Sleeper struct {
 func (sl *Sleeper) Send(c *skogul.Container) error {
 	d := sl.Base.Duration + time.Duration(rand.Float64()*float64(sl.MaxDelay.Duration))
 	if sl.Verbose {
-		log.WithField("duration", d).Debug("Sleeping")
+		debugLog.WithField("duration", d).Debug("Sleeping")
 	}
 	time.Sleep(d)
 	return sl.Next.S.Send(c)

--- a/sender/detacher.go
+++ b/sender/detacher.go
@@ -27,10 +27,10 @@ import (
 	"runtime"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var detachLog = skogul.Logger("sender", "detacher")
 
 /*
 These senders are somewhat controversial, as they affect the fanout/fan-in
@@ -69,7 +69,7 @@ func (de *Detacher) consume() {
 func (de *Detacher) doInit() {
 	if de.Depth == 0 {
 		de.Depth = 1000
-		log.WithField("depth", de.Depth).Debug("No detach depth/queue depth set. Using default value.")
+		detachLog.WithField("depth", de.Depth).Debug("No detach depth/queue depth set. Using default value.")
 	}
 	de.ch = make(chan *skogul.Container, de.Depth)
 	go de.consume()
@@ -111,7 +111,7 @@ func (fo *Fanout) doInit() {
 	if fo.Workers == 0 {
 		n := runtime.NumCPU()
 		fo.Workers = n
-		log.WithField("fanout", fo.Workers).Debug("No fanout size set. Using default value")
+		detachLog.WithField("fanout", fo.Workers).Debug("No fanout size set. Using default value")
 	}
 	fo.workers = make(chan chan *skogul.Container)
 	for i := 0; i < fo.Workers; i++ {

--- a/sender/fallback.go
+++ b/sender/fallback.go
@@ -24,8 +24,6 @@
 package sender
 
 import (
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
 
@@ -78,6 +76,9 @@ func (dp *Dupe) Send(c *skogul.Container) error {
 	return e
 }
 
+// logLog logs to a log. Loggingly.
+var logLog = skogul.Logger("sender", "log")
+
 /*
 Log sender simply executes log.Print() on a predefined message.
 
@@ -90,6 +91,6 @@ type Log struct {
 
 // Send logs a message and does no further processing
 func (lg Log) Send(c *skogul.Container) error {
-	log.Debug(lg.Message)
+	logLog.Debug(lg.Message)
 	return nil
 }

--- a/sender/mnr.go
+++ b/sender/mnr.go
@@ -28,10 +28,10 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var mnrLog = skogul.Logger("sender", "mnr")
 
 /*
 MnR sender writes to M&R port collector.
@@ -106,7 +106,7 @@ be negligible. But this should, of course, be fixed in the future.
 func (mnr *MnR) Send(c *skogul.Container) error {
 	d, err := net.Dial("tcp", mnr.Address)
 	if err != nil {
-		log.WithError(err).WithField("address", mnr.Address).Error("Failed to connect to MnR")
+		mnrLog.WithError(err).WithField("address", mnr.Address).Error("Failed to connect to MnR")
 		return skogul.Error{Source: "mnr sender", Reason: "unable to connect to MnR"}
 	}
 	for _, m := range c.Metrics {

--- a/sender/mqtt.go
+++ b/sender/mqtt.go
@@ -27,11 +27,11 @@ import (
 	"encoding/json"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 	skmqtt "github.com/telenornms/skogul/internal/mqtt"
 )
+
+var mqttLog = skogul.Logger("sender", "mqtt")
 
 /*
 MQTT Sender publishes messages on a MQTT message bus.
@@ -56,7 +56,7 @@ func (handler *MQTT) Send(c *skogul.Container) error {
 	})
 	b, err := json.MarshalIndent(*c, "", "  ")
 	if err != nil {
-		log.WithError(err).Panic("Unable to marshal json for debug output")
+		mqttLog.WithError(err).Panic("Unable to marshal json for debug output")
 		return err
 	}
 	handler.mc.Client.Publish(handler.mc.Topic, 0, false, b)

--- a/sender/net.go
+++ b/sender/net.go
@@ -28,10 +28,10 @@ import (
 	"fmt"
 	"net"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/telenornms/skogul"
 )
+
+var netLog = skogul.Logger("sender", "net")
 
 // Net sends metrics to a network address
 type Net struct {
@@ -43,7 +43,7 @@ type Net struct {
 func (n *Net) Send(c *skogul.Container) error {
 	d, err := net.Dial(n.Network, n.Address)
 	if err != nil {
-		log.WithError(err).WithField("address", n.Address).Error("Failed to connect to target")
+		netLog.WithError(err).WithField("address", n.Address).Error("Failed to connect to target")
 		return skogul.Error{Source: "net sender", Reason: "unable to connect to network address", Next: err}
 	}
 	// should almost certainly fix some method of retaining the

--- a/transformer/edit.go
+++ b/transformer/edit.go
@@ -25,12 +25,13 @@ package transformer
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"sync"
 
 	"github.com/telenornms/skogul"
 )
+
+var repLog = skogul.Logger("transformer", "edit")
 
 // Replace executes a regular expression replacement of metric metadata.
 type Replace struct {
@@ -73,7 +74,7 @@ func (replace *Replace) Transform(c *skogul.Container) error {
 			// the same memory, which can create unexpected
 			// behavior if other transformers want to modify
 			// just one of the headers.
-			log.Printf("Unable to transform non-string field %s with content %v", replace.Source, c.Metrics[mi].Metadata[replace.Source])
+			repLog.WithField("source", replace.Source).Printf("Unable to transform non-string field %s with content %v", replace.Source, c.Metrics[mi].Metadata[replace.Source])
 			// This is to confirm with the documentation and
 			// ensure that this isn't exploited by providing a
 			// bogus Source-field only to be able to provide a


### PR DESCRIPTION
I'm not 100% sold on this idea, but: If we are going down the logrus-route, we need to ensure the data fields we provide are usable. That means some sort of theme or standardized minimum.

What bugs me about this, and logrus for that matter, is that the code becomes cluttered. I much prefer log.Printf("foo: %v", x) over this WithField("foo",x) thing. This patch also means each code-entity needs a local "logger-instance", which isn't a big deal, but means that log.Print("HI") becomes localLog.Print("HI"). 

This patch mainly aims to unify our approach to logging, and can be a starting point. It is best read by reading common.go and just a couple of other of the files, since it's mostly identical fixes to introduce "local scope". The result is that every log item will have a field "source" referencing what it is (sender/receiver/transformer/parser/core) and a separate field indicating the implementation. E.g.:

```
INFO[0001] Starting INSECURE http receiver (no TLS)      address="[::1]:1386" receiver=http source=receiver
ERRO[0001] HTTP response status code was not in OK range  error="http sender: non-OK status code from target: 400" sender=http source=sender
ERRO[0001] Failed to do POST request                     error="http sender: unable to POST request: Post http://[::1]:1/foobar: dial tcp [::1]:1: connect: connection refused" sender=http source=sender
INFO[0001] unable to read root ca: EOF                   sender=http source=sender
ERRO[0001] Invalid item configuration                    core=config family=sender name=bad1 source=core
INFO[0001] unable to open alternate root CA: open /dev/no/proc/such/sys/file/run/lol/kek/why/are/you/still/reading/this: no such file or directory  sender=http source=sender
ERRO[0001] Invalid item configuration                    core=config family=sender name=bad2 source=core
DEBU[0002] Verifying sender configuration                core=config sender=bad source=core
ERRO[0002] Invalid item configuration                    core=config family=sender name=bad source=core
DEBU[0002] Verifying sender configuration                core=config sender=bad source=core
ERRO[0002] Invalid item configuration                    core=config family=sender name=bad source=core
DEBU[0002] Resolving sender                              core=config sender=fail source=core
DEBU[0002] Resolving sender                              core=config sender=ok source=core
DEBU[0002] Resolving sender                              core=config sender=ignore source=core
DEBU[0002] Resolving sender                              core=config sender=fake-fail source=core
DEBU[0002] Verifying sender configuration                core=config sender=ignore source=core
```

I think we can discuss this, and merge it to try it out, even if we reserve the right to reverse our approach to logging.

References #39 