### PR TITLE
config: Account for tabs in syntax errors

### DIFF
--- a/config/parse.go
+++ b/config/parse.go
@@ -215,7 +215,11 @@ func printSyntaxError(b []byte, offset int, text string) {
 	fmt.Printf("Unable to parse JSON configuration at byte offset %d.\nError: %s\nContext:\n", offset, text)
 	fmt.Println(string(b[start:end2]))
 	for i := start2; i < (offset - 2); i++ {
-		fmt.Print("-")
+		if b[i] == '	' {
+			fmt.Print("--------")
+		} else {
+			fmt.Print("-")
+		}
 	}
 	// We found the crappy part!
 	fmt.Println("💩")

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -246,6 +246,17 @@ func Test_syntaxError(t *testing.T) {
       }
     }
   }`)
+	testBadConf(t,
+		`{
+	"senders": {
+		"tnet_alarms":: {
+			"type": "sql",
+			"Driver": "mysql",
+			"ConnStr":: "root:lol@/mydb",
+			"Query": "INERT INTO tnet_Alarms values(${foo})"
+		}
+	}
+}`)
 }
 func TestFindSuperfluousReceiverConfigProperties(t *testing.T) {
 	rawConfig := []byte(`{"receivers": {


### PR DESCRIPTION
Still doesn't account for other non-1-char-wide characters though, but
this should cover 99% of all related issues.