### PR TITLE
Generalize modules and expose custom data structures

### DIFF
--- a/config/parse.go
+++ b/config/parse.go
@@ -112,7 +112,9 @@ func (t *Transformer) UnmarshalJSON(b []byte) error {
 	if transformer.Auto[t.Type].Alloc == nil {
 		return skogul.Error{Source: "config parser", Reason: fmt.Sprintf("Bad transformer %v", t.Type)}
 	}
-	t.Transformer = transformer.Auto[t.Type].Alloc()
+	var ok bool
+	t.Transformer, ok = (transformer.Auto[t.Type].Alloc()).(skogul.Transformer)
+	skogul.Assert(ok)
 	if err := json.Unmarshal(b, &t.Transformer); err != nil {
 		return skogul.Error{Source: "config parser", Reason: "Failed marshalling", Next: err}
 	}
@@ -136,7 +138,9 @@ func (r *Receiver) UnmarshalJSON(b []byte) error {
 	if receiver.Auto[r.Type].Alloc == nil {
 		return skogul.Error{Source: "config parser", Reason: fmt.Sprintf("Bad receiver %v", r.Type)}
 	}
-	r.Receiver = receiver.Auto[r.Type].Alloc()
+	var ok bool
+	r.Receiver, ok = (receiver.Auto[r.Type].Alloc()).(skogul.Receiver)
+	skogul.Assert(ok)
 	if err := json.Unmarshal(b, &r.Receiver); err != nil {
 		return skogul.Error{Source: "config parser", Reason: "Failed marshalling", Next: err}
 	}
@@ -174,7 +178,9 @@ func (s *Sender) UnmarshalJSON(b []byte) error {
 	if sender.Auto[s.Type].Alloc == nil {
 		return skogul.Error{Source: "config parser", Reason: fmt.Sprintf("Bad sender %v", s.Type)}
 	}
-	s.Sender = sender.Auto[s.Type].Alloc()
+	var ok bool
+	s.Sender, ok = (sender.Auto[s.Type].Alloc()).(skogul.Sender)
+	skogul.Assert(ok)
 	if err := json.Unmarshal(b, &s.Sender); err != nil {
 		return skogul.Error{Source: "config parser", Reason: "Failed marshalling", Next: err}
 	}

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/telenornms/skogul"
 	"github.com/telenornms/skogul/receiver"
+	"github.com/telenornms/skogul/sender"
 )
 
 func TestFile(t *testing.T) {
@@ -107,10 +108,10 @@ func TestByte_ok(t *testing.T) {
 
 }
 
-func TestHelpSender(t *testing.T) {
-	_, err := HelpSender("sql")
+func TestHelpModule(t *testing.T) {
+	_, err := HelpModule(sender.Auto, "sql")
 	if err != nil {
-		t.Errorf("HelpSender(\"sql\") didn't work: %v", err)
+		t.Errorf("HelpModule(sender.Auto,\"sql\") didn't work: %v", err)
 	}
 }
 

--- a/modules.go
+++ b/modules.go
@@ -1,0 +1,62 @@
+/*
+ * skogul, module automation utilities
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package skogul
+
+// Module is metadata for a skogul module. It is used by the receiver,
+// sender and transformer package. The Alloc() function must return a
+// data structure that implements the relevant module interface, which is
+// checked primarily in config.Parse.
+//
+// See */auto.go for how to utilize this, and config/help.go,
+// cmd/skogul/main.go for how to extract information/help, and ultimately
+// config/parse.go for how it is applied.
+type Module struct {
+	Name    string             // short name of the module (e.g: "http"
+	Aliases []string           // optional aliases (e.g. "https")
+	Alloc   func() interface{} // allocation of a blank module structure
+	Extras  []interface{}      // Optional additional custom data structures that should be exposed in documentation.
+	Help    string             // Human-readable help description.
+}
+
+// ModuleMap maps a name of a module to the Module data structure. Each
+// type of module has its own module map. E.g.: receiver.Auto, sender.Auto
+// and transformer.Auto.
+type ModuleMap map[string]*Module
+
+// Add adds a module to a module map, ensuring basic sanity and announcing
+// it to the world, so to speak.
+func (amap *ModuleMap) Add(item Module) error {
+	if *amap == nil {
+		*amap = make(map[string]*Module)
+	}
+	lm := *amap
+	Assert(lm[item.Name] == nil)
+	Assert(item.Alloc != nil)
+	for _, alias := range item.Aliases {
+		Assert(lm[alias] == nil)
+		lm[alias] = &item
+	}
+	lm[item.Name] = &item
+	return nil
+}

--- a/modules.go
+++ b/modules.go
@@ -32,7 +32,7 @@ package skogul
 // cmd/skogul/main.go for how to extract information/help, and ultimately
 // config/parse.go for how it is applied.
 type Module struct {
-	Name    string             // short name of the module (e.g: "http"
+	Name    string             // short name of the module (e.g: "http")
 	Aliases []string           // optional aliases (e.g. "https")
 	Alloc   func() interface{} // allocation of a blank module structure
 	Extras  []interface{}      // Optional additional custom data structures that should be exposed in documentation.

--- a/receiver/auto.go
+++ b/receiver/auto.go
@@ -32,78 +32,54 @@ import (
 )
 
 // Auto maps names to Receivers to allow auto configuration
-var Auto map[string]*Receiver
-
-// Receiver is the generic data for all receivers, used for
-// auto-configuration and more.
-type Receiver struct {
-	Name    string
-	Aliases []string
-	Alloc   func() skogul.Receiver
-	Help    string
-}
-
-// Add is used to announce a receiver-implementation to the world, so to
-// speak. It is exported to allow out-of-package senders to exist.
-func Add(r Receiver) error {
-	if Auto == nil {
-		Auto = make(map[string]*Receiver)
-	}
-	skogul.Assert(Auto[r.Name] == nil)
-	skogul.Assert(r.Alloc != nil)
-	for _, alias := range r.Aliases {
-		skogul.Assert(Auto[alias] == nil)
-		Auto[alias] = &r
-	}
-	Auto[r.Name] = &r
-	return nil
-}
+var Auto skogul.ModuleMap
 
 func init() {
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:    "http",
 		Aliases: []string{"https"},
-		Alloc:   func() skogul.Receiver { return &HTTP{} },
+		Alloc:   func() interface{} { return &HTTP{} },
 		Help:    "Listen for metrics on HTTP or HTTPS. Optionally requiring authentication. Each request received is passed to the handler.",
+		Extras:  []interface{}{HTTPAuth{}},
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "file",
-		Alloc: func() skogul.Receiver { return &File{} },
+		Alloc: func() interface{} { return &File{} },
 		Help:  "Reads from a file, then stops. Assumes one collection per line.",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "fifo",
-		Alloc: func() skogul.Receiver { return &LineFile{} },
+		Alloc: func() interface{} { return &LineFile{} },
 		Help:  "Reads continuously from a file. Can technically read from any file, but since it will re-open and re-read the file upon EOF, it is best suited for reading a fifo. Assumes one collection per line.",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "log",
-		Alloc: func() skogul.Receiver { return &Log{} },
+		Alloc: func() interface{} { return &Log{} },
 		Help:  "Log attaches to the internal logging of Skogul and diverts log messages.",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "mqtt",
-		Alloc: func() skogul.Receiver { return &MQTT{} },
+		Alloc: func() interface{} { return &MQTT{} },
 		Help:  "Listen for Skogul-formatted JSON on a MQTT endpoint",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "stdin",
-		Alloc: func() skogul.Receiver { return &Stdin{} },
+		Alloc: func() interface{} { return &Stdin{} },
 		Help:  "Reads from standard input, one collection per line, allowing you to pipe collections to Skogul on a command line or similar.",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "test",
-		Alloc: func() skogul.Receiver { return &Tester{} },
+		Alloc: func() interface{} { return &Tester{} },
 		Help:  "Generate dummy-data. Useful for testing, including in combination with the http sender to send dummy-data to an other skogul instance.",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "tcp",
-		Alloc: func() skogul.Receiver { return &TCPLine{} },
+		Alloc: func() interface{} { return &TCPLine{} },
 		Help:  "Listen for Skogul-formatted JSON on a tcp socket, reading one collection per line.",
 	})
-	Add(Receiver{
+	Auto.Add(skogul.Module{
 		Name:  "udp",
-		Alloc: func() skogul.Receiver { return &UDP{} },
+		Alloc: func() interface{} { return &UDP{} },
 		Help:  "Accept UDP messages, parsed by specified handler. E.g.: Protobuf.",
 	})
 }

--- a/sender/auto.go
+++ b/sender/auto.go
@@ -27,142 +27,118 @@ import (
 	"github.com/telenornms/skogul"
 )
 
-// Sender provides a framework that all sender-implementations should
-// follow, and allows auto-initialization.
-type Sender struct {
-	Name    string
-	Aliases []string
-	Alloc   func() skogul.Sender
-	Help    string
-}
-
 // Auto maps sender-names to sender implementation, used for auto
 // configuration.
-var Auto map[string]*Sender
-
-// Add announces the existence of a sender to the world at large.
-func Add(s Sender) error {
-	if Auto == nil {
-		Auto = make(map[string]*Sender)
-	}
-	skogul.Assert(Auto[s.Name] == nil)
-	skogul.Assert(s.Alloc != nil)
-	Auto[s.Name] = &s
-	for _, alias := range s.Aliases {
-		skogul.Assert(Auto[alias] == nil)
-		Auto[alias] = &s
-	}
-	return nil
-}
+var Auto skogul.ModuleMap
 
 func init() {
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "backoff",
 		Aliases: []string{"retry"},
-		Alloc:   func() skogul.Sender { return &Backoff{} },
+		Alloc:   func() interface{} { return &Backoff{} },
 		Help:    "Forwards data to the next sender, retrying after a delay upon failure. For each retry, the delay is doubled. Gives up after the set number of retries.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "batch",
 		Aliases: []string{"batcher"},
-		Alloc:   func() skogul.Sender { return &Batch{} },
+		Alloc:   func() interface{} { return &Batch{} },
 		Help:    "Accepts metrics and puts them in a shared container. When the container either has a set number of metrics (Threshold), or a timeout occurs, the entire container is forwarded. This allows down-stream senders to work with larger batches of metrics at a time, which is frequently more efficient. A side effect of this is that down-stream errors are not propogated upstream. That means any errors need to be dealt with down stream, or they will be ignored.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "counter",
 		Aliases: []string{"count"},
-		Alloc:   func() skogul.Sender { return &Counter{} },
+		Alloc:   func() interface{} { return &Counter{} },
 		Help:    "Accepts metrics, counts them and passes them on. Then emits statistics to the Stats-handler on an interval.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "debug",
-		Alloc: func() skogul.Sender { return &Debug{} },
+		Alloc: func() interface{} { return &Debug{} },
 		Help:  "Prints received metrics to stdout.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "detacher",
 		Aliases: []string{"detach"},
-		Alloc:   func() skogul.Sender { return &Detacher{} },
+		Alloc:   func() interface{} { return &Detacher{} },
 		Help:    "Returns OK without waiting for the next sender to finish.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "dupe",
 		Aliases: []string{"dup", "duplicate"},
-		Alloc:   func() skogul.Sender { return &Dupe{} },
+		Alloc:   func() interface{} { return &Dupe{} },
 		Help:    "Sends the same metrics to all senders listed in Next.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "errdiverter",
 		Aliases: []string{"errordiverter", "errdivert", "errordivert"},
-		Alloc:   func() skogul.Sender { return &ErrDiverter{} },
+		Alloc:   func() interface{} { return &ErrDiverter{} },
 		Help:    "Forwards data to next sender. If an error is returned, the error is converted into a Skogul container and sent to the err-handler. This provides the means of logging errors through regular skogul-chains.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "fanout",
-		Alloc: func() skogul.Sender { return &Fanout{} },
+		Alloc: func() interface{} { return &Fanout{} },
 		Help:  "Fanout to a fixed number of threads before passing data on. This is rarely needed, as receivers should do this.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "fallback",
-		Alloc: func() skogul.Sender { return &Fallback{} },
+		Alloc: func() interface{} { return &Fallback{} },
 		Help:  "Tries the senders provided in Next, in order. E.g.: if the first responds OK, the second will never get data. Useful for diverting traffic to alternate paths upon failure.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "forwardfail",
-		Alloc: func() skogul.Sender { return &ForwardAndFail{} },
+		Alloc: func() interface{} { return &ForwardAndFail{} },
 		Help:  "Forwards metrics, but always returns failure. Useful in complex failure handling involving e.g. fallback sender, where it might be used to write log or stats on failure while still propogating a failure upward.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "http",
 		Aliases: []string{"https"},
-		Alloc:   func() skogul.Sender { return &HTTP{} },
+		Alloc:   func() interface{} { return &HTTP{} },
 		Help:    "Sends Skogul-formatted JSON-data to a HTTP endpoint (e.g.: an other Skogul instance?). Highly useful in scenarios with multiple data collection methods spread over several servers.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "influx",
 		Aliases: []string{"influxdb"},
-		Alloc:   func() skogul.Sender { return &InfluxDB{} },
+		Alloc:   func() interface{} { return &InfluxDB{} },
 		Help:    "Send to a InfluxDB HTTP endpoint. The sender can either always send the data to a single measurement, send it to a measurement extracted from the metadata of a metric, or a combination where the \"measurement\" serves as a default measurement to use if the metric doesn't have the key presented in \"measurementfrommetadata\".",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "log",
-		Alloc: func() skogul.Sender { return &Log{} },
+		Alloc: func() interface{} { return &Log{} },
 		Help:  "Logs a message, mainly useful for enriching debug information in conjunction with, for example, dupe and debug.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:    "mnr",
 		Aliases: []string{"m&r"},
-		Alloc:   func() skogul.Sender { return &MnR{} },
+		Alloc:   func() interface{} { return &MnR{} },
 		Help:    "Sends M&R line format to a TCP endpoint.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "mqtt",
-		Alloc: func() skogul.Sender { return &MQTT{} },
+		Alloc: func() interface{} { return &MQTT{} },
 		Help:  "Publishes received metrics to an MQTT broker/topic.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "sql",
-		Alloc: func() skogul.Sender { return &SQL{} },
+		Alloc: func() interface{} { return &SQL{} },
 		Help:  "Execute a SQL query for each received metric, using a template. Any query can be run, and if multiple metrics are present in the same container, they are all executed in a single transaction, which means the batch-sender will greatly increase performance. Supported engines are MySQL/MariaDB and Postgres.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "null",
-		Alloc: func() skogul.Sender { return &Null{} },
+		Alloc: func() interface{} { return &Null{} },
 		Help:  "Discards all data. Mainly useful for testing.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "sleep",
-		Alloc: func() skogul.Sender { return &Sleeper{} },
+		Alloc: func() interface{} { return &Sleeper{} },
 		Help:  "Injects a random delay before passing data on. Mainly for testing.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "net",
-		Alloc: func() skogul.Sender { return &Net{} },
+		Alloc: func() interface{} { return &Net{} },
 		Help:  "Sends json data to a network endpoint.",
 	})
-	Add(Sender{
+	Auto.Add(skogul.Module{
 		Name:  "test",
-		Alloc: func() skogul.Sender { return &Test{} },
+		Alloc: func() interface{} { return &Test{} },
 		Help:  "Used for internal testing. Basically just discards data but provides an internal counter of received data",
 	})
 

--- a/skogul.1
+++ b/skogul.1
@@ -553,6 +553,9 @@ Address to listen to.
 .sp
 Example(s): [::1]:80 [2001:db8::1]:443
 .TP
+.B \fBauth \- map[string]*receiver.HTTPAuth\fP
+A map corresponding to Handlers; specifying authentication for the given path, if required.
+.TP
 .B \fBcertfile \- string\fP
 Path to certificate file for TLS. If left blank, un\-encrypted HTTP is used.
 .TP
@@ -563,6 +566,12 @@ Example(s): {"/": "someHandler" }
 .TP
 .B \fBkeyfile \- string\fP
 Path to key file for TLS.
+.UNINDENT
+.sp
+Custom type \fBHTTPAuth\fP
+.sp
+Settings:
+.INDENT 0.0
 .TP
 .B \fBpassword \- string\fP
 Password for basic authentication.
@@ -745,6 +754,16 @@ Fail the transformer entirely if split is unsuccsessful on a metric container. T
 .TP
 .B \fBfield \- []string\fP
 Split into multiple metrics based on this field (each field denotes the path to a nested object element).
+.UNINDENT
+.SS switch
+.sp
+Conditionally apply transformers
+.sp
+Settings:
+.INDENT 0.0
+.TP
+.B \fBcases \- []transformer.Case\fP
+A list of switch cases
 .UNINDENT
 .SS templater
 .sp

--- a/skogul.rst
+++ b/skogul.rst
@@ -531,6 +531,9 @@ Settings:
 
 	Example(s): [::1]:80 [2001:db8::1]:443
 
+``auth - map[string]*receiver.HTTPAuth``
+	A map corresponding to Handlers; specifying authentication for the given path, if required.
+
 ``certfile - string``
 	Path to certificate file for TLS. If left blank, un-encrypted HTTP is used.
 
@@ -541,6 +544,10 @@ Settings:
 
 ``keyfile - string``
 	Path to key file for TLS.
+
+Custom type ``HTTPAuth``
+
+Settings:
 
 ``password - string``
 	Password for basic authentication.
@@ -643,7 +650,6 @@ Settings:
 	Handler used to parse, transform and send data.
 
 
-
 TRANSFORMERS
 ============
 
@@ -727,6 +733,16 @@ Settings:
 
 ``field - []string``
 	Split into multiple metrics based on this field (each field denotes the path to a nested object element).
+
+switch
+------
+
+Conditionally apply transformers
+
+Settings:
+
+``cases - []transformer.Case``
+	A list of switch cases 
 
 templater
 ---------

--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -5,68 +5,44 @@ import (
 )
 
 // Auto maps names to Transformers to allow auto configuration
-var Auto map[string]*Transformer
-
-// Transformer is the generic data for all transformers, used for
-// auto-configuration and more.
-type Transformer struct {
-	Name    string
-	Aliases []string
-	Alloc   func() skogul.Transformer
-	Help    string
-}
-
-// Add is used to announce a transformer-implementation to the world, so to
-// speak. It is exported to allow out-of-package senders to exist.
-func Add(r Transformer) error {
-	if Auto == nil {
-		Auto = make(map[string]*Transformer)
-	}
-	skogul.Assert(Auto[r.Name] == nil)
-	skogul.Assert(r.Alloc != nil)
-	for _, alias := range r.Aliases {
-		skogul.Assert(Auto[alias] == nil)
-		Auto[alias] = &r
-	}
-	Auto[r.Name] = &r
-	return nil
-}
+var Auto skogul.ModuleMap
 
 func init() {
-	Add(Transformer{
+	Auto.Add(skogul.Module{
 		Name:    "templater",
 		Aliases: []string{"template", "templating"},
-		Alloc:   func() skogul.Transformer { return Templater{} },
+		Alloc:   func() interface{} { return Templater{} },
 		Help:    "Executes metric templating. See separate documentationf or how skogul templating works.",
 	})
-	Add(Transformer{
+	Auto.Add(skogul.Module{
 		Name:    "metadata",
 		Aliases: []string{},
-		Alloc:   func() skogul.Transformer { return &Metadata{} },
+		Alloc:   func() interface{} { return &Metadata{} },
 		Help:    "Enforces custom-rules on metadata of metrics.",
 	})
-	Add(Transformer{
+	Auto.Add(skogul.Module{
 		Name:    "data",
 		Aliases: []string{},
-		Alloc:   func() skogul.Transformer { return &Data{} },
+		Alloc:   func() interface{} { return &Data{} },
 		Help:    "Enforces custom-rules for data fields of metrics.",
 	})
-	Add(Transformer{
+	Auto.Add(skogul.Module{
 		Name:    "split",
 		Aliases: []string{},
-		Alloc:   func() skogul.Transformer { return &Split{} },
+		Alloc:   func() interface{} { return &Split{} },
 		Help:    "Splits a metric into multiple metrics based on a field.",
 	})
-	Add(Transformer{
+	Auto.Add(skogul.Module{
 		Name:    "replace",
 		Aliases: []string{},
-		Alloc:   func() skogul.Transformer { return &Replace{} },
+		Alloc:   func() interface{} { return &Replace{} },
 		Help:    "Uses a regular expression to replace the content of a metadata key, storing it to either a different metadata key, or overwriting the original.",
 	})
-	Add(Transformer{
+	Auto.Add(skogul.Module{
 		Name:    "switch",
 		Aliases: []string{},
-		Alloc:   func() skogul.Transformer { return &Switch{} },
+		Alloc:   func() interface{} { return &Switch{} },
 		Help:    "Conditionally apply transformers",
+		Extras:  []interface{}{Case{}},
 	})
 }


### PR DESCRIPTION
The worthwhile changes here moves most of the logic from */auto.go into
modules.go. It's the same basic logic, but instead of
Receiver/Sender/Transformer, there's a generic Module structure.

This dramatically reduces the complexity of config/help.go and
cmd/skogul/main.go.

This also introduces "Extras" to the Module data structure, which allows
modules to list a set of custom data structures that should also be
visible in documentation. The Extras field is currently _only_ used for
documentation.

For review, begin with modules.go, comparing it to e.g. sender/auto.go.

Fixes #73