### PR TITLE
fix: Append a provisioned transformer; not a nil one

### DIFF
--- a/common.go
+++ b/common.go
@@ -220,9 +220,9 @@ func (h Handler) Verify() error {
 	if h.Transformers == nil {
 		return Error{Reason: "Missing parser for Handler"}
 	}
-	for _, t := range h.Transformers {
+	for i, t := range h.Transformers {
 		if t == nil {
-			return Error{Reason: "nil-transformer for Handler"}
+			return Error{Source: "handler verification", Reason: fmt.Sprintf("nil-transformer %d for Handler",i)}
 		}
 	}
 	if h.Sender == nil {

--- a/common.go
+++ b/common.go
@@ -222,7 +222,7 @@ func (h Handler) Verify() error {
 	}
 	for i, t := range h.Transformers {
 		if t == nil {
-			return Error{Source: "handler verification", Reason: fmt.Sprintf("nil-transformer %d for Handler",i)}
+			return Error{Source: "handler verification", Reason: fmt.Sprintf("nil-transformer %d for Handler", i)}
 		}
 	}
 	if h.Sender == nil {

--- a/config/parse.go
+++ b/config/parse.go
@@ -316,7 +316,7 @@ func resolveHandlers(c *Config) error {
 			logger = logger.WithField("transformer", t.Name)
 			logger.Debug("Using predefined transformer")
 
-			h.Handler.Transformers = append(h.Handler.Transformers, t.T)
+			h.Handler.Transformers = append(h.Handler.Transformers, c.Transformers[t.Name].Transformer)
 		}
 	}
 	for _, h := range skogul.HandlerMap {

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -69,8 +69,13 @@ func TestByte_ok(t *testing.T) {
     "plain": {
       "parser": "json",
       "sender": "batch",
-      "transformers": []
+      "transformers": ["foo"]
     }
+  },
+  "transformers": {
+	  "foo": {
+		  "type": "templater"
+	  }
   },
   "receivers": {
     "http": {

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -258,6 +258,64 @@ func Test_syntaxError(t *testing.T) {
 		}
 	}
 }`)
+
+	_, err := Bytes([]byte(`{
+    "receivers": {
+      "udp": {
+        "type": "udp",
+        "address": "[::1]:5015",
+        "handler": "protobuf"
+      }
+    },
+    "handlers": {
+      "protobuf": {
+        "parser": "protobuf",
+        "transformers": ["remove", "remove2", "remove3", "remove4", "remove5"],
+        "sender": "print"
+      }
+    },
+    "transformers": {
+      "sw": {
+        "type": "switch",
+        "cases": [
+          {
+            "when": "sensorName",
+            "is": "junos_system_linecard_intf-exp:/junos/system/linecard/intf-exp/:/junos/system/linecard/intf-exp/:PFE",
+            "transformers": ["remove"]
+          }
+        ]
+      },
+      "remove": {
+        "type": "data",
+        "remove": ["interfaceExp_stats"]
+      },
+      "remove2": {
+        "type": "data",
+        "remove": ["interfaceExp_stats"]
+      },
+      "remove3": {
+        "type": "data",
+        "remove": ["interfaceExp_stats"]
+      },
+      "remove4": {
+        "type": "data",
+        "remove": ["interfaceExp_stats"]
+      },
+      "remove5": {
+        "type": "data",
+        "remove": ["interfaceExp_stats"]
+      }
+    },
+    "senders": {
+      "print": {
+        "type": "debug",
+        "prefix": "DEBUG"
+      }
+    }
+  }`))
+	if err != nil {
+		t.Errorf("Expected config to pass: %v", err)
+	}
 }
 func TestFindSuperfluousReceiverConfigProperties(t *testing.T) {
 	rawConfig := []byte(`{"receivers": {

--- a/sender/fallback.go
+++ b/sender/fallback.go
@@ -45,7 +45,7 @@ This will send data to Influx normally. If Influx fails, it will send it to
 a queue. If that fails, it will print it to stdout.
 */
 type Fallback struct {
-	Next []skogul.SenderRef `doc:"Ordered list of senders that will potentially receive metrics."`
+	Next []*skogul.SenderRef `doc:"Ordered list of senders that will potentially receive metrics."`
 }
 
 // Send sends data down stream
@@ -61,7 +61,7 @@ func (fb *Fallback) Send(c *skogul.Container) error {
 
 // Dupe sender executes all provided senders in turn.
 type Dupe struct {
-	Next []skogul.SenderRef `doc:"List of senders that will receive metrics, in order."`
+	Next []*skogul.SenderRef `doc:"List of senders that will receive metrics, in order."`
 }
 
 // Send sends data down stream

--- a/sender/int_test.go
+++ b/sender/int_test.go
@@ -44,7 +44,7 @@ func TestDupe(t *testing.T) {
 	c := skogul.Container{}
 	one := &(sender.Test{})
 	two := &(sender.Test{})
-	dupe := sender.Dupe{Next: []skogul.SenderRef{{S: one}, {S: two}}}
+	dupe := sender.Dupe{Next: []*skogul.SenderRef{{S: one}, {S: two}}}
 
 	err := dupe.Send(&c)
 	if err != nil {
@@ -108,7 +108,7 @@ func TestFallback_fail(t *testing.T) {
 	two := &(sender.Test{})
 	three := &(sender.Test{})
 	faf := &(sender.ForwardAndFail{Next: skogul.SenderRef{S: one}})
-	fb := sender.Fallback{Next: []skogul.SenderRef{{S: faf}, {S: two}, {S: three}}}
+	fb := sender.Fallback{Next: []*skogul.SenderRef{{S: faf}, {S: two}, {S: three}}}
 
 	err := fb.Send(&c)
 	if err != nil {

--- a/skogul.1
+++ b/skogul.1
@@ -290,7 +290,7 @@ Aliases: duplicate dup
 Settings:
 .INDENT 0.0
 .TP
-.B \fBnext \- []skogul.SenderRef\fP
+.B \fBnext \- []*skogul.SenderRef\fP
 List of senders that will receive metrics, in order.
 .UNINDENT
 .SS errdiverter
@@ -318,7 +318,7 @@ Tries the senders provided in Next, in order. E.g.: if the first responds OK, th
 Settings:
 .INDENT 0.0
 .TP
-.B \fBnext \- []skogul.SenderRef\fP
+.B \fBnext \- []*skogul.SenderRef\fP
 Ordered list of senders that will potentially receive metrics.
 .UNINDENT
 .SS fanout
@@ -764,6 +764,21 @@ Settings:
 .TP
 .B \fBcases \- []transformer.Case\fP
 A list of switch cases
+.UNINDENT
+.sp
+Custom type \fBCase\fP
+.sp
+Settings:
+.INDENT 0.0
+.TP
+.B \fBis \- string\fP
+Used for the specific value (string) of the stated metadata field
+.TP
+.B \fBtransformers \- []*skogul.TransformerRef\fP
+The transformers to run when the defined conditional is true
+.TP
+.B \fBwhen \- string\fP
+Used as a conditional statement on a field
 .UNINDENT
 .SS templater
 .sp

--- a/skogul.rst
+++ b/skogul.rst
@@ -261,7 +261,7 @@ Aliases: duplicate dup
 
 Settings:
 
-``next - []skogul.SenderRef``
+``next - []*skogul.SenderRef``
 	List of senders that will receive metrics, in order.
 
 errdiverter
@@ -289,7 +289,7 @@ Tries the senders provided in Next, in order. E.g.: if the first responds OK, th
 
 Settings:
 
-``next - []skogul.SenderRef``
+``next - []*skogul.SenderRef``
 	Ordered list of senders that will potentially receive metrics.
 
 fanout
@@ -743,6 +743,19 @@ Settings:
 
 ``cases - []transformer.Case``
 	A list of switch cases 
+
+Custom type ``Case``
+
+Settings:
+
+``is - string``
+	Used for the specific value (string) of the stated metadata field
+
+``transformers - []*skogul.TransformerRef``
+	The transformers to run when the defined conditional is true
+
+``when - string``
+	Used as a conditional statement on a field
 
 templater
 ---------

--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -11,7 +11,7 @@ func init() {
 	Auto.Add(skogul.Module{
 		Name:    "templater",
 		Aliases: []string{"template", "templating"},
-		Alloc:   func() interface{} { return Templater{} },
+		Alloc:   func() interface{} { return &Templater{} },
 		Help:    "Executes metric templating. See separate documentationf or how skogul templating works.",
 	})
 	Auto.Add(skogul.Module{

--- a/transformer/switch.go
+++ b/transformer/switch.go
@@ -30,8 +30,8 @@ import (
 // Case requires a field ("when") and a value ("is") to match
 // for the set of transformers to run
 type Case struct {
-	When         string                  `doc:"Used as a conditional statement on a field"`
-	Is           string                  `doc:"Used for the specific value (string) of the stated metadata field"`
+	When         string                   `doc:"Used as a conditional statement on a field"`
+	Is           string                   `doc:"Used for the specific value (string) of the stated metadata field"`
 	Transformers []*skogul.TransformerRef `doc:"The transformers to run when the defined conditional is true"`
 }
 

--- a/transformer/switch.go
+++ b/transformer/switch.go
@@ -32,7 +32,7 @@ import (
 type Case struct {
 	When         string                  `doc:"Used as a conditional statement on a field"`
 	Is           string                  `doc:"Used for the specific value (string) of the stated metadata field"`
-	Transformers []skogul.TransformerRef `doc:"The transformers to run when the defined conditional is true"`
+	Transformers []*skogul.TransformerRef `doc:"The transformers to run when the defined conditional is true"`
 }
 
 // Switch is a wrapper for a list of cases


### PR DESCRIPTION
After #71, this piece of code was not updated to use allocated transformers, but rather the transformer from the list it looped over. In some rare occurrences, this could be a nil value.

See example config which fails on 3dfe4ee5abb936add0bc45dc212b06ae9aa0aeff (and newer) in the supplied test case.