### PR TITLE
Tighten metedata transformer's extract logic

### DIFF
--- a/transformer/metadata.go
+++ b/transformer/metadata.go
@@ -34,7 +34,7 @@ import (
 type Metadata struct {
 	Set             map[string]interface{} `doc:"Set metadata fields to specific values."`
 	Require         []string               `doc:"Require the pressence of these fields."`
-	ExtractFromData []string               `doc:"Extract a set of fields from Data and add it to Metadata."`
+	ExtractFromData []string               `doc:"Extract a set of fields from Data and add it to Metadata. Removes the original."`
 	Remove          []string               `doc:"Remove these metadata fields."`
 	Ban             []string               `doc:"Fail if any of these fields are present"`
 }
@@ -54,8 +54,11 @@ func (meta *Metadata) Transform(c *skogul.Container) error {
 			}
 		}
 		for _, extract := range meta.ExtractFromData {
-
+			if _, ok := c.Metrics[mi].Data[extract]; !ok {
+				continue
+			}
 			c.Metrics[mi].Metadata[extract] = c.Metrics[mi].Data[extract]
+			delete(c.Metrics[mi].Data, extract)
 		}
 		for _, value := range meta.Remove {
 			if c.Metrics[mi].Metadata == nil {

--- a/transformer/metadata_test.go
+++ b/transformer/metadata_test.go
@@ -150,7 +150,7 @@ func TestExtract(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	metadata := transformer.Metadata{
-		ExtractFromData: []string{extracted_value_key},
+		ExtractFromData: []string{extracted_value_key, "empty_key"},
 	}
 
 	err := metadata.Transform(&c)
@@ -161,6 +161,15 @@ func TestExtract(t *testing.T) {
 
 	if c.Metrics[0].Metadata[extracted_value_key] != extracted_value {
 		t.Errorf(`Expected %s but got %s`, extracted_value, c.Metrics[0].Metadata[extracted_value_key])
+	}
+	if _, ok := c.Metrics[0].Data["empty_key"]; ok {
+		t.Errorf(`Data key 'empty_key' is set after extraction`)
+	}
+	if _, ok := c.Metrics[0].Metadata["empty_key"]; ok {
+		t.Errorf(`Metadata key 'empty_key' is set after extraction`)
+	}
+	if _, ok := c.Metrics[0].Data[extracted_value_key]; ok {
+		t.Errorf(`Data key %s is still set after extraction`, extracted_value_key)
 	}
 }
 


### PR DESCRIPTION
Fixes #78
Fixes #79

Ensures empty keys are not created and that if an extraction is carried
through, the original key is unset/deleted.