### PR TITLE
Make Handler.Parser internal to its module as its functions are exposed already

### DIFF
--- a/common.go
+++ b/common.go
@@ -44,7 +44,7 @@ used in the future.
 To make it configurable, a HandlerRef should be used.
 */
 type Handler struct {
-	Parser       Parser
+	parser       Parser
 	Transformers []Transformer
 	Sender       Sender
 }
@@ -171,9 +171,21 @@ func (e Error) Container() Container {
 	return c
 }
 
+// SetParser sets the parser to use for a Handler
+func (h *Handler) SetParser(p Parser) error {
+	if h.parser != nil {
+		return Error{Source: "handler", Reason: "Handler already has a parser set"}
+	}
+	if p == nil {
+		return Error{Source: "handler", Reason: "Attempting to set parser to 'nil'"}
+	}
+	h.parser = p
+	return nil
+}
+
 // Parse parses the bytes into a Container
 func (h *Handler) Parse(b []byte) (*Container, error) {
-	c, err := h.Parser.Parse(b)
+	c, err := h.parser.Parse(b)
 	if err != nil {
 		return nil, Error{Source: "handler", Reason: "parsing data failed", Next: err}
 	}
@@ -220,7 +232,7 @@ func (h *Handler) TransformAndSend(c *Container) error {
 
 // Verify the basic integrity of a handler. Quite shallow.
 func (h Handler) Verify() error {
-	if h.Parser == nil {
+	if h.parser == nil {
 		return Error{Reason: "Missing parser for Handler"}
 	}
 	for i, t := range h.Transformers {

--- a/common_test.go
+++ b/common_test.go
@@ -32,10 +32,14 @@ import (
 
 func TestHandler(t *testing.T) {
 	h1 := skogul.Handler{}
-	h2 := skogul.Handler{Parser: parser.JSON{}}
-	h3 := skogul.Handler{Parser: parser.JSON{}, Transformers: []skogul.Transformer{}}
-	h4 := skogul.Handler{Parser: parser.JSON{}, Transformers: []skogul.Transformer{}, Sender: &(sender.Test{})}
-	h5 := skogul.Handler{Parser: parser.JSON{}, Transformers: []skogul.Transformer{nil}, Sender: &(sender.Test{})}
+	h2 := skogul.Handler{}
+	h2.SetParser(parser.JSON{})
+	h3 := skogul.Handler{Transformers: []skogul.Transformer{}}
+	h3.SetParser(parser.JSON{})
+	h4 := skogul.Handler{Transformers: []skogul.Transformer{}, Sender: &(sender.Test{})}
+	h4.SetParser(parser.JSON{})
+	h5 := skogul.Handler{Transformers: []skogul.Transformer{nil}, Sender: &(sender.Test{})}
+	h5.SetParser(parser.JSON{})
 
 	err := h1.Verify()
 	if err == nil {

--- a/config/parse.go
+++ b/config/parse.go
@@ -307,13 +307,13 @@ func resolveHandlers(c *Config) error {
 		h.Handler.Transformers = make([]skogul.Transformer, 0)
 		if h.Parser == "protobuf" {
 			logger.Debug("Using protobuf parser")
-			h.Handler.Parser = parser.ProtoBuf{}
+			h.Handler.SetParser(parser.ProtoBuf{})
 		} else if h.Parser == "custom-json" {
 			logger.Debug("Using custom JSON parser")
-			h.Handler.Parser = parser.RawJSON{}
+			h.Handler.SetParser(parser.RawJSON{})
 		} else if h.Parser == "json" || h.Parser == "" {
 			logger.Debug("Using JSON parser")
-			h.Handler.Parser = parser.JSON{}
+			h.Handler.SetParser(parser.JSON{})
 		} else {
 			logger.Error("Unknown parser")
 			return skogul.Error{Source: "config", Reason: fmt.Sprintf("Unknown parser %s", h.Parser)}

--- a/receiver/examples_test.go
+++ b/receiver/examples_test.go
@@ -36,8 +36,10 @@ HTTP can have different skogul.Handler's for different paths, with potentially d
 */
 func ExampleHTTP() {
 	h := receiver.HTTP{Address: "localhost:8080"}
-	template := skogul.Handler{Parser: parser.JSON{}, Transformers: []skogul.Transformer{transformer.Templater{}}, Sender: &sender.Debug{}}
-	noTemplate := skogul.Handler{Parser: parser.JSON{}, Sender: &sender.Debug{}}
+	template := skogul.Handler{Transformers: []skogul.Transformer{transformer.Templater{}}, Sender: &sender.Debug{}}
+	template.SetParser(parser.JSON{})
+	noTemplate := skogul.Handler{Sender: &sender.Debug{}}
+	noTemplate.SetParser(parser.JSON{})
 	h.Handlers = map[string]*skogul.HandlerRef{
 		"/template":   {H: &template},
 		"/notemplate": {H: &noTemplate},

--- a/receiver/tester_test.go
+++ b/receiver/tester_test.go
@@ -34,7 +34,8 @@ import (
 
 func TestTester_stack(t *testing.T) {
 	one := &(sender.Test{})
-	h := skogul.Handler{Sender: one, Parser: parser.JSON{}}
+	h := skogul.Handler{Sender: one}
+	h.SetParser(parser.JSON{})
 	rcv := receiver.Tester{Metrics: 10, Values: 5, Threads: 2, Handler: skogul.HandlerRef{H: &h}}
 	go rcv.Start()
 
@@ -52,7 +53,8 @@ func TestTester_stack(t *testing.T) {
 
 func TestTester_auto(t *testing.T) {
 	one := &(sender.Test{})
-	h := skogul.Handler{Sender: one, Parser: parser.JSON{}}
+	h := skogul.Handler{Sender: one}
+	h.SetParser(parser.JSON{})
 	parsedD, _ := time.ParseDuration("1s")
 	x := receiver.Tester{
 		Handler: skogul.HandlerRef{H: &h},

--- a/sender/complex_test.go
+++ b/sender/complex_test.go
@@ -57,7 +57,8 @@ func TestHttp_stack(t *testing.T) {
 
 	port := 1337 + rand.Intn(100)
 	adr := fmt.Sprintf("localhost:%d", port)
-	h := skogul.Handler{Sender: one, Parser: parser.JSON{}}
+	h := skogul.Handler{Sender: one}
+	h.SetParser(parser.JSON{})
 	rcv := receiver.HTTP{Address: adr, Handlers: map[string]*skogul.HandlerRef{"/": {H: &h}}}
 	//	rcv.Handle("/", &h)
 	go rcv.Start()

--- a/sender/counter_test.go
+++ b/sender/counter_test.go
@@ -35,7 +35,8 @@ func TestCounter(t *testing.T) {
 	one := &(sender.Test{})
 	two := &(sender.Test{})
 
-	h := skogul.Handler{Sender: one, Parser: parser.JSON{}}
+	h := skogul.Handler{Sender: one}
+	h.SetParser(parser.JSON{})
 	cnt := sender.Counter{Next: skogul.SenderRef{S: two}, Stats: skogul.HandlerRef{H: &h}, Period: skogul.Duration{Duration: time.Duration(50 * time.Millisecond)}}
 	two.TestQuick(t, &cnt, &validContainer, 1)
 	if one.Received() != 0 {


### PR DESCRIPTION
This makes it easier to avoid "bypassing" the Parse() function exposed by the Handler.

I'm not completely sure if I want to do this or not, so feel free to comment.