### PR TITLE
Benchmark JSON parsers

### DIFF
--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -21,17 +21,20 @@
  * 02110-1301  USA
  */
 
-package parser
+package parser_test
 
-import "testing"
+import (
+	"io/ioutil"
+	"testing"
 
-import "io/ioutil"
+	"github.com/telenornms/skogul/parser"
+)
 
 // TestJSONParse tests parsing of a simple JSON document to skogul
 // container
 func TestJSONParse(t *testing.T) {
 	b := []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
-	x := JSON{}
+	x := parser.JSON{}
 	_, err := x.Parse(b)
 	if err != nil {
 		t.Errorf("JSON.Parse(b) failed: %s", err)
@@ -40,7 +43,7 @@ func TestJSONParse(t *testing.T) {
 
 func BenchmarkJSONParse(b *testing.B) {
 	by := []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
-	x := JSON{}
+	x := parser.JSON{}
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}
@@ -54,7 +57,7 @@ func TestRawJSONParse(t *testing.T) {
 		return
 	}
 
-	container, err := RawJSON{}.Parse(b)
+	container, err := parser.RawJSON{}.Parse(b)
 
 	if err != nil {
 		t.Errorf("Failed to parse JSON data: %v", err)
@@ -69,7 +72,7 @@ func TestRawJSONParse(t *testing.T) {
 
 func BenchmarkRawJSONParse(b *testing.B) {
 	by := []byte(`{"string":"text","float":1.11,"integer":5,"timestamp":"2019-03-15T11:08:02+01:00","key":"value"}`)
-	x := RawJSON{}
+	x := parser.RawJSON{}
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -66,3 +66,11 @@ func TestRawJSONParse(t *testing.T) {
 		return
 	}
 }
+
+func BenchmarkRawJSONParse(b *testing.B) {
+	by := []byte(`{"string":"text","float":1.11,"integer":5,"timestamp":"2019-03-15T11:08:02+01:00","key":"value"}`)
+	x := RawJSON{}
+	for i := 0; i < b.N; i++ {
+		x.Parse(by)
+	}
+}

--- a/parser/protobuf_test.go
+++ b/parser/protobuf_test.go
@@ -21,11 +21,13 @@
  * 02110-1301  USA
  */
 
-package parser
+package parser_test
 
 import (
 	"os"
 	"testing"
+
+	"github.com/telenornms/skogul/parser"
 )
 
 type failer interface {
@@ -53,7 +55,7 @@ func readProtobufFile(t failer, file string) []byte {
 
 func TestProtoBuf(t *testing.T) {
 	b := readProtobufFile(t, "testdata/protobuf-packet.bin")
-	x := ProtoBuf{}
+	x := parser.ProtoBuf{}
 	c, err := x.Parse(b)
 	if err != nil {
 		t.Errorf("ProtoBuf.Parse(b) failed: %s", err)
@@ -65,7 +67,7 @@ func TestProtoBuf(t *testing.T) {
 
 func BenchmarkProtoBufParse(b *testing.B) {
 	by := readProtobufFile(b, "testdata/protobuf-packet.bin")
-	x := ProtoBuf{}
+	x := parser.ProtoBuf{}
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}


### PR DESCRIPTION
```
$ go test ./parser -bench "JSON" -benchtime 30s
goos: darwin
goarch: amd64
pkg: github.com/telenornms/skogul/parser
BenchmarkJSONParse-16       	 8567155	      4287 ns/op
BenchmarkRawJSONParse-16    	11517844	      3096 ns/op
```