### PR TITLE
fix: Build release RPMs in a centos image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,8 +24,22 @@ steps:
   image: golang
   commands:
   - apt-get update
-  - apt-get -y install python-docutils bzip2 gawk rpm
+  - apt-get -y install python-docutils bzip2 gawk
   - ./make-release.sh ${DRONE_TAG}
+  when:
+    event:
+    - tag
+
+- name: prepare-centos-release
+  image: centos:7
+  environment:
+    SHELL: /bin/bash
+  commands:
+  - yum install -y git python-docutils rpm-build wget
+  - wget https://storage.googleapis.com/golang/getgo/installer_linux
+  - chmod +x installer_linux
+  - ./installer_linux
+  - source /root/.bash_profile
   - ./make-rpm.sh ${DRONE_TAG}
   when:
     event:
@@ -44,6 +58,9 @@ steps:
     - skogul-*.rpm
     note: notes
     title: Skogul ${DRONE_TAG}
+  depends_on:
+    - prepare-release
+    - prepare-centos-release
   when:
     event:
     - tag

--- a/make-rpm.sh
+++ b/make-rpm.sh
@@ -40,10 +40,10 @@ Source0:        https://github.com/telenornms/skogul/archive/$V.tar.gz
 
 
 BuildArch:      $ARCH
-# The build requirements. However, because we build
-# in a docker container with ubuntu
-# rpm doesn't know that the requirements are available.
-#BuildRequires:  go >= 1.13, python-docutils
+# Since we download go manually and not through yum,
+# the version won't be registered as installed.
+#BuildRequires:  go >= 1.13
+BuildRequires:  python-docutils, systemd-units
 
 
 %description


### PR DESCRIPTION
This should make sure we have the BuildRequirements available