### PR TITLE
Add and use skogul.Now() as an approximation of time.Now()

### DIFF
--- a/parser/json.go
+++ b/parser/json.go
@@ -25,7 +25,6 @@ package parser
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/telenornms/skogul"
 )
@@ -50,7 +49,7 @@ func (data RawJSON) Parse(b []byte) (*skogul.Container, error) {
 
 	// The Validate() func of a container expects a timestamp to be valid.
 	// Better way to fix?
-	time := time.Now()
+	time := skogul.Now()
 	metric := skogul.Metric{
 		Metadata: make(map[string]interface{}),
 		Time:     &time,

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,74 @@
+/*
+ * skogul, time syncer
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package skogul
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+const syncPeriod = time.Millisecond * 100
+
+var ltime struct {
+	sec  int64
+	nsec int64
+}
+
+func init() {
+	go syncTime()
+}
+
+func syncTime() {
+	f := func() {
+		t := time.Now()
+		s := int64(t.Unix())
+		ns := int64(t.Nanosecond())
+		atomic.StoreInt64(&ltime.sec, s)
+		atomic.StoreInt64(&ltime.nsec, ns)
+	}
+	f()
+	myticker := time.NewTicker(syncPeriod)
+	for {
+		select {
+		case <-myticker.C:
+			f()
+		}
+	}
+}
+
+/*
+Now returns an approximation of time.Now atomically. It his is achieved by
+syncing time in a separate go routine to reduce overhead. Currently synced
+10 times per second. The reason you may want this is:
+
+	BenchmarkTimeNow-8     	130269282	        45.6 ns/op
+	BenchmarkSkogulNow-8   	1000000000	         0.878 ns/op
+
+If ten times per second isn't accurate enough, we may consider making this
+configurable. The primary use case here is for transformers or parsers that
+need to insert time, but might get thousands of metrics per second.
+*/
+func Now() time.Time {
+	return time.Unix(ltime.sec, ltime.nsec)
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,0 +1,65 @@
+/*
+ * skogul, timer benchmarks
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package skogul_test
+
+import (
+	"github.com/telenornms/skogul"
+	"testing"
+	"time"
+)
+
+func wait() {
+	myt := time.NewTimer(time.Millisecond * 200)
+	<-myt.C
+}
+
+func TestNow(t *testing.T) {
+	start := skogul.Now()
+	wait()
+	two := skogul.Now()
+	if !start.Before(two) {
+		t.Errorf("skogul.Now() in the middle was not after skogul.Now() from the start")
+	}
+	middle_now := time.Now()
+	if !start.Before(middle_now) {
+		t.Errorf("time.Now() in the middle was not after skogul.Now() from the start")
+	}
+	wait()
+	three := skogul.Now()
+	if !middle_now.Before(three) {
+		t.Errorf("time.Now() in the middle was not before skogul.Now() from the end: middle_now: %v three: %v", middle_now, three)
+	}
+}
+
+func BenchmarkTimeNow(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		time.Now()
+	}
+}
+
+func BenchmarkSkogulNow(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		skogul.Now()
+	}
+}


### PR DESCRIPTION
Benchmarks sort of speak for them self:

```
BenchmarkTimeNow-8     	130818974	        45.8 ns/op
BenchmarkSkogulNow-8   	1000000000	         0.884 ns/op
```

I chose updates every 100ms as an arbitrary compromise, and we can always revisit this. The basic idea is simple: Have a go routine periodically update a global time stamp, then any code that needs Now can use that value without trying local optimizations, instead of doing a systemcall for it.