### PR TITLE
Run skogul one-off on some data

### DIFF
--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -42,6 +42,8 @@ import (
 	"github.com/telenornms/skogul/transformer"
 )
 
+var mainLogger = skogul.Logger("main", "main")
+
 // versionNo gets set by passing the -X flag to ld like this
 // go build -ldflags "-X main.versionNo=0.1.0" ./cmd/skogul
 var versionNo string
@@ -53,6 +55,7 @@ var fman = flag.Bool("make-man", false, "Output RST documentation suited for rst
 var floglevel = flag.String("loglevel", "warn", "Minimum loglevel to display ([e]rror, [w]arn, [i]nfo, [d]ebug, [t]race/[v]erbose)")
 var ftimestamp = flag.Bool("timestamp", true, "Include timestamp in log entries")
 var fversion = flag.Bool("version", false, "Print skogul version")
+var ftest = flag.Bool("test", false, "Run skogul one-off on some data. By default it reads from stdin, but it can also use a config file.")
 
 // man generates an RST document suited for converting to a manual page
 // using rst2man. The RST document itself is also valid, but some short
@@ -757,6 +760,18 @@ func main() {
 		fmt.Println(string(out))
 		os.Exit(0)
 	}
+
+	if *ftest {
+		err = config.RunTestWithConfig(c)
+
+		if err != nil {
+			mainLogger.WithError(err).Error("One-off run with configuration failed")
+			os.Exit(1)
+		}
+
+		os.Exit(0)
+	}
+
 	log.Info("Starting skogul")
 
 	var exitInt = 0

--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -55,7 +55,7 @@ var fman = flag.Bool("make-man", false, "Output RST documentation suited for rst
 var floglevel = flag.String("loglevel", "warn", "Minimum loglevel to display ([e]rror, [w]arn, [i]nfo, [d]ebug, [t]race/[v]erbose)")
 var ftimestamp = flag.Bool("timestamp", true, "Include timestamp in log entries")
 var fversion = flag.Bool("version", false, "Print skogul version")
-var ftest = flag.Bool("test", false, "Run skogul one-off on some data. By default it reads from stdin, but it can also use a config file.")
+var ftest = flag.Bool("test", false, "Run skogul one-off on some data. By default it reads from stdin, but it can also use a config file. (-f)")
 
 // man generates an RST document suited for converting to a manual page
 // using rst2man. The RST document itself is also valid, but some short

--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -746,9 +746,17 @@ func main() {
 		os.Exit(0)
 	}
 
-	c, err := config.File(*ffile)
-	if err != nil {
-		log.Fatal(err)
+	var c *config.Config
+
+	// Allow config file to be missing if running in -test mode,
+	// require it otherwise.
+	_, confFileErr := os.Stat(*ffile)
+	if !*ftest && os.IsNotExist(confFileErr) {
+		var err error
+		c, err = config.File(*ffile)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if *fconf {
@@ -762,7 +770,7 @@ func main() {
 	}
 
 	if *ftest {
-		err = config.RunTestWithConfig(c)
+		err := config.RunTestWithConfig(c)
 
 		if err != nil {
 			mainLogger.WithError(err).Error("One-off run with configuration failed")

--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -770,10 +770,10 @@ func main() {
 	}
 
 	if *ftest {
-		err := config.RunTestWithConfig(c)
+		err := config.OneOff(c)
 
 		if err != nil {
-			mainLogger.WithError(err).Error("One-off run with configuration failed")
+			mainLogger.WithError(err).Error("One-off run failed")
 			os.Exit(1)
 		}
 

--- a/config/debug.go
+++ b/config/debug.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/parser"
+	"github.com/telenornms/skogul/receiver"
+	"github.com/telenornms/skogul/sender"
+)
+
+// RunTestWithConfig runs skogul with only a debugger
+// The debugger can be configured all the way through
+// using a configuration file, and by overriding either
+// the receiver, handler or sender. The ones not defined
+// will be automatically defined with some defaults.
+// If nothing is defined, the default behaviour is to
+// * Read from /dev/stdin
+// * Parse the input as "skogul-JSON" (container format)
+// * Run no transformers
+// * Print the result to stdout
+func RunTestWithConfig(conf *Config) error {
+	const debuggerName = "_debugger"
+
+	debugSender := sender.Debug{}
+
+	var debugHandlerRef skogul.HandlerRef
+	// If no handler is specified, create a simple one.
+	if conf.Handlers[debuggerName] == nil {
+		debugHandler := skogul.Handler{
+			Sender: &debugSender,
+		}
+		debugHandler.SetParser(parser.JSON{})
+
+		debugHandlerRef = skogul.HandlerRef{
+			H:    &debugHandler,
+			Name: debuggerName,
+		}
+	} else {
+		// If a _debugger handler is specified, re-use relevant pieces
+		// of the config and re-apply them to relevant configurations
+		_debugHandler := conf.Handlers[debuggerName]
+		transformers := make([]skogul.Transformer, 0)
+
+		for _, t := range _debugHandler.Transformers {
+			transformers = append(transformers, t.T)
+		}
+
+		debugHandler := skogul.Handler{
+			Sender:       _debugHandler.Sender.S,
+			Transformers: transformers,
+		}
+		debugHandler.SetParser(parser.JSON{})
+		debugHandlerRef = skogul.HandlerRef{
+			H:    &debugHandler,
+			Name: debuggerName,
+		}
+	}
+
+	// If a receiver is specified, use that.
+	// Otherwise, initialise a simple stdin reader.
+	if conf.Receivers[debuggerName] == nil {
+		recvHandler := Receiver{
+			Receiver: &receiver.Stdin{
+				Handler: debugHandlerRef,
+			},
+		}
+		conf.Receivers[debuggerName] = &recvHandler
+	}
+
+	return conf.Receivers[debuggerName].Receiver.Start()
+}

--- a/config/debug.go
+++ b/config/debug.go
@@ -18,6 +18,16 @@ import (
 // * Run no transformers
 // * Print the result to stdout
 func RunTestWithConfig(conf *Config) error {
+
+	if conf == nil {
+		conf = &Config{
+			Handlers:     make(map[string]*Handler),
+			Receivers:    make(map[string]*Receiver),
+			Senders:      make(map[string]*Sender),
+			Transformers: make(map[string]*Transformer),
+		}
+	}
+
 	const debuggerName = "_debugger"
 
 	debugSender := sender.Debug{}

--- a/config/debug.go
+++ b/config/debug.go
@@ -7,7 +7,7 @@ import (
 	"github.com/telenornms/skogul/sender"
 )
 
-// RunTestWithConfig runs skogul with only a debugger
+// OneOff runs skogul with only a debugger
 // The debugger can be configured all the way through
 // using a configuration file, and by overriding either
 // the receiver, handler or sender. The ones not defined
@@ -17,7 +17,7 @@ import (
 // * Parse the input as "skogul-JSON" (container format)
 // * Run no transformers
 // * Print the result to stdout
-func RunTestWithConfig(conf *Config) error {
+func OneOff(conf *Config) error {
 
 	if conf == nil {
 		conf = &Config{

--- a/docs/examples/debug.json
+++ b/docs/examples/debug.json
@@ -1,0 +1,21 @@
+{
+  "receivers": {},
+  "handlers": {
+    "_debugger": {
+      "parser": "json",
+      "transformers": ["remove_string"],
+      "sender": "print"
+    }
+  },
+  "transformers": {
+    "remove_string": {
+      "type": "data",
+      "remove": ["string"]
+    }
+  },
+  "senders": {
+    "print": {
+      "type": "debug"
+    }
+  }
+}

--- a/skogul.1
+++ b/skogul.1
@@ -92,6 +92,9 @@ Output RST documentation suited for rst2man (default false)
 .B \fB\-show\fP
 Print the parsed JSON config instead of starting (default false)
 .TP
+.B \fB\-test\fP
+Run skogul one\-off on some data. By default it reads from stdin, but it can also use a config file. (\-f) (default false)
+.TP
 .B \fB\-timestamp\fP
 Include timestamp in log entries (default true)
 .UNINDENT

--- a/skogul.rst
+++ b/skogul.rst
@@ -66,6 +66,9 @@ OPTIONS
 ``-show``
 	Print the parsed JSON config instead of starting (default false)
 
+``-test``
+	Run skogul one-off on some data. By default it reads from stdin, but it can also use a config file. (-f) (default false)
+
 ``-timestamp``
 	Include timestamp in log entries (default true)
 


### PR DESCRIPTION
Adds the `-test` flag which adds a "_debugger" receiver, handler and sender. These can be configured in a configuration file as normal (though the name is required to be "_debugger") to customise, but will default to reading from stdin, parsing as skogul-json, transforming nothing and finally outputting to stdout.