### PR TITLE
Multi file config

### DIFF
--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -48,6 +48,7 @@ import (
 var versionNo string
 
 var ffile = flag.String("f", "~/.config/skogul.json", "Path to skogul config to read.")
+var fconfigDir = flag.String("d", "", "Path to skogul configuration files.")
 var fhelp = flag.Bool("help", false, "Print more help")
 var fconf = flag.Bool("show", false, "Print the parsed JSON config instead of starting")
 var fman = flag.Bool("make-man", false, "Output RST documentation suited for rst2man")
@@ -746,9 +747,20 @@ func main() {
 		os.Exit(0)
 	}
 
-	c, err := config.File(*ffile)
-	if err != nil {
-		log.Fatal(err)
+	var c *config.Config
+
+	if *fconfigDir != "" {
+		var err error
+		c, err = config.ReadFiles(*fconfigDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		var err error
+		c, err = config.File(*ffile)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if *fconf {

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -384,7 +384,7 @@ func TestMergeConfigFiles(t *testing.T) {
 	_ = json.Unmarshal([]byte(handler), &configs[2])
 	_ = json.Unmarshal([]byte(sender), &configs[3])
 
-	c, err := config.MergeRawConfigs(configs)
+	c, err := config.MergeRawConfigs(configs, nil)
 
 	if err != nil {
 		t.Errorf("Failed to merge two valid configurations: %s", err)
@@ -419,7 +419,7 @@ func TestMergeConfigFilesConflicts(t *testing.T) {
 	_ = json.Unmarshal([]byte(conf1), &configs[0])
 	_ = json.Unmarshal([]byte(conf2), &configs[1])
 
-	_, err := config.MergeRawConfigs(configs)
+	_, err := config.MergeRawConfigs(configs, nil)
 
 	if err == nil {
 		t.Error("Merged two configurations with conflicting keys")

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -425,3 +425,15 @@ func TestMergeConfigFilesConflicts(t *testing.T) {
 		t.Error("Merged two configurations with conflicting keys")
 	}
 }
+
+func TestReadConfigFiles(t *testing.T) {
+	c, err := config.ReadFiles("testdata/configs")
+
+	if err != nil {
+		t.Error("Error from config read files", err)
+	}
+
+	if c.Receivers["foo"] == nil || c.Receivers["bar"] == nil {
+		t.Error("Missing a receiver which should be configured")
+	}
+}

--- a/config/testdata/configs/invalid
+++ b/config/testdata/configs/invalid
@@ -1,0 +1,8 @@
+{
+    "receivers": {
+        "bar": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    }
+}

--- a/config/testdata/configs/invalid.txt
+++ b/config/testdata/configs/invalid.txt
@@ -1,0 +1,8 @@
+{
+    "receivers": {
+        "bar": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    }
+}

--- a/config/testdata/configs/valid-one.json
+++ b/config/testdata/configs/valid-one.json
@@ -1,0 +1,8 @@
+{
+    "receivers": {
+        "bar": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    }
+}

--- a/config/testdata/configs/valid2.json
+++ b/config/testdata/configs/valid2.json
@@ -1,0 +1,19 @@
+{
+    "receivers": {
+        "foo": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    },
+    "handlers": {
+        "baz": {
+            "parser": "json",
+            "sender": "qux"
+        }
+    },
+    "senders": {
+        "qux": {
+            "type": "debug"
+        }
+    }
+}


### PR DESCRIPTION
Should be pretty self explanatory, but I'll add a quick note.

This change request adds the feature detailed in #82 which suggests adding support for reading a directory for configuration files.

This is added by a new program flag (currently -d but that can be changed as it's usually used for --debug etc), which calls into ReadFiles from the configuration package. This reads all files ending in `.json`, parses them as JSON (and will fail if it's not valid JSON). After identifying and reading the files, it will marshal it back to JSON and then unmarshal it into a larger configuration object, after which it runs the normal Bytes()-configuration parsing.

There's no need to define each section in each file, so it's possible to only define what you want (e.g. a single receiver). Inside each section, a key is unique. This is the same as in regular JSON (and regular skogul config), defining the same key multiple times is ambiguous and wouldn't work today.