### PR TITLE
feat: Add loading config from directory of config files

### DIFF
--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -750,6 +750,10 @@ func main() {
 	var c *config.Config
 
 	if *fconfigDir != "" {
+		if _, err := os.Stat(*fconfigDir); os.IsNotExist(err) {
+			log.Fatalf("Directory '%s' does not exist", *fconfigDir)
+		}
+
 		var err error
 		c, err = config.ReadFiles(*fconfigDir)
 		if err != nil {

--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -48,6 +48,7 @@ import (
 var versionNo string
 
 var ffile = flag.String("f", "~/.config/skogul.json", "Path to skogul config to read.")
+var fconfigDir = flag.String("d", "", "Path to skogul configuration files.")
 var fhelp = flag.Bool("help", false, "Print more help")
 var fconf = flag.Bool("show", false, "Print the parsed JSON config instead of starting")
 var fman = flag.Bool("make-man", false, "Output RST documentation suited for rst2man")
@@ -746,9 +747,20 @@ func main() {
 		os.Exit(0)
 	}
 
-	c, err := config.File(*ffile)
-	if err != nil {
-		log.Fatal(err)
+	var c *config.Config
+
+	if *fconfigDir != "" {
+		var err error
+		c, err = config.ReadFiles(*fconfigDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		var err error
+		c, err = config.File(*ffile)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if *fconf {

--- a/config/parse.go
+++ b/config/parse.go
@@ -296,8 +296,7 @@ func findConfigFiles(path string) ([]string, error) {
 	confLog.WithField("path", path).Debugf("Reading configuration files from %s", path)
 	configFiles := make([]string, 0)
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() && len(strings.Split(path, ".")) > 1 &&
-			strings.ToLower(strings.Split(path, ".")[1]) == "json" {
+		if !info.IsDir() && filepath.Ext(path) == ".json" {
 			configFiles = append(configFiles, path)
 		}
 		return err

--- a/config/parse.go
+++ b/config/parse.go
@@ -30,6 +30,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -118,6 +120,11 @@ func (t *Transformer) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &t.Transformer); err != nil {
 		return skogul.Error{Source: "config parser", Reason: "Failed marshalling", Next: err}
 	}
+
+	// Find superfluous config parameters
+	var jsonConf map[string]interface{}
+	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	VerifyOnlyRequiredConfigProps(&jsonConf, "transformer", t.Type, reflect.ValueOf(t.Transformer).Elem().Type())
 	return nil
 }
 
@@ -144,6 +151,11 @@ func (r *Receiver) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &r.Receiver); err != nil {
 		return skogul.Error{Source: "config parser", Reason: "Failed marshalling", Next: err}
 	}
+
+	// Find superfluous config parameters
+	var jsonConf map[string]interface{}
+	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	VerifyOnlyRequiredConfigProps(&jsonConf, "receiver", r.Type, reflect.ValueOf(r.Receiver).Elem().Type())
 	return nil
 }
 
@@ -184,6 +196,10 @@ func (s *Sender) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s.Sender); err != nil {
 		return skogul.Error{Source: "config parser", Reason: "Failed marshalling", Next: err}
 	}
+	// Find superfluous config parameters
+	var jsonConf map[string]interface{}
+	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	VerifyOnlyRequiredConfigProps(&jsonConf, "sender", s.Type, reflect.ValueOf(s.Sender).Elem().Type())
 	return nil
 }
 
@@ -262,7 +278,7 @@ func Bytes(b []byte) (*Config, error) {
 		return nil, skogul.Error{Source: "config parser", Reason: "Unable to parse JSON config", Next: err}
 	}
 
-	return secondPass(&c, &jsonData)
+	return secondPass(&c)
 }
 
 // File opens a config file and parses it, then returns the valid
@@ -274,6 +290,57 @@ func File(f string) (*Config, error) {
 		return nil, skogul.Error{Source: "config parser", Reason: "Failed to read config file", Next: err}
 	}
 	return Bytes(dat)
+}
+
+func findConfigFiles(path string) ([]string, error) {
+	confLog.WithField("path", path).Debugf("Reading configuration files from %s", path)
+	configFiles := make([]string, 0)
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() && len(strings.Split(path, ".")) > 1 &&
+			strings.ToLower(strings.Split(path, ".")[1]) == "json" {
+			configFiles = append(configFiles, path)
+		}
+		return err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return configFiles, nil
+}
+
+// ReadFiles reads all JSON files (with the .JSON suffix) in a given directory
+// and combines them to a configuration for the program.
+func ReadFiles(p string) (*Config, error) {
+	files, err := findConfigFiles(p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	config := Config{}
+
+	for _, f := range files {
+		confLog.WithField("file", f).Debug("Reading file")
+		b, err := ioutil.ReadFile(f)
+
+		if err != nil {
+			confLog.WithError(err).Error("Failed to read config file")
+			return nil, skogul.Error{Source: "config:parser", Reason: "Failed to read config file", Next: err}
+		}
+
+		err = json.Unmarshal(b, &config)
+		if err != nil {
+			jerr, ok := err.(*json.SyntaxError)
+			if ok {
+				printSyntaxError(b, int(jerr.Offset), jerr.Error())
+			}
+			return nil, err
+		}
+	}
+
+	return secondPass(&config)
 }
 
 // resolveSenders iterates over the skogul.SenderMap and resolves senders,
@@ -361,7 +428,7 @@ func resolveTransformers(c *Config) error {
 
 // secondPass accepts a parsed configuration as input and resolves the
 // references in it, and verifies basic integrity.
-func secondPass(c *Config, jsonData *map[string]interface{}) (*Config, error) {
+func secondPass(c *Config) (*Config, error) {
 	if err := resolveSenders(c); err != nil {
 		return nil, err
 	}
@@ -377,36 +444,24 @@ func secondPass(c *Config, jsonData *map[string]interface{}) (*Config, error) {
 		if err := verifyItem("handler", idx, h.Handler); err != nil {
 			return nil, err
 		}
-
-		configStruct := reflect.TypeOf(h.Handler)
-		VerifyOnlyRequiredConfigProps(jsonData, "handlers", idx, configStruct)
 	}
 	for idx, t := range c.Transformers {
 		confLog.WithField("transformer", idx).Debug("Verifying transformer configuration")
 		if err := verifyItem("transformer", idx, t.Transformer); err != nil {
 			return nil, err
 		}
-
-		configStruct := reflect.ValueOf(t.Transformer).Elem().Type()
-		VerifyOnlyRequiredConfigProps(jsonData, "transformers", idx, configStruct)
 	}
 	for idx, s := range c.Senders {
 		confLog.WithField("sender", idx).Debug("Verifying sender configuration")
 		if err := verifyItem("sender", idx, s.Sender); err != nil {
 			return nil, err
 		}
-
-		configStruct := reflect.ValueOf(s.Sender).Elem().Type()
-		VerifyOnlyRequiredConfigProps(jsonData, "senders", idx, configStruct)
 	}
 	for idx, r := range c.Receivers {
 		confLog.WithField("receiver", idx).Debug("Verifying receiver configuration")
 		if err := verifyItem("receiver", idx, r.Receiver); err != nil {
 			return nil, err
 		}
-
-		configStruct := reflect.ValueOf(r.Receiver).Elem().Type()
-		VerifyOnlyRequiredConfigProps(jsonData, "receivers", idx, configStruct)
 	}
 
 	return c, nil
@@ -448,7 +503,9 @@ func findFieldsOfStruct(T reflect.Type) []string {
 	return requiredProps
 }
 
-func getRelevantRawConfigSection(rawConfig *map[string]interface{}, family, section string) map[string]interface{} {
+// GetRelevantRawConfigSection is a helper function to dig down into a Config JSON
+// and select the wanted family (receivers, transformers, senders) and item (foo).
+func GetRelevantRawConfigSection(rawConfig *map[string]interface{}, family, section string) map[string]interface{} {
 	configFamily, ok := (*rawConfig)[family].(map[string]interface{})
 	if !ok {
 		confLog.WithFields(logrus.Fields{
@@ -471,14 +528,13 @@ func getRelevantRawConfigSection(rawConfig *map[string]interface{}, family, sect
 
 // VerifyOnlyRequiredConfigProps checks for undefined configuration properties
 // It can be used to identify typos or invalid configuration
-func VerifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family, handler string, T reflect.Type) []string {
+// Use 'config.GetRelevantRawConfigSection' first for handler if you have a full config.
+func VerifyOnlyRequiredConfigProps(componentConfig *map[string]interface{}, family, handler string, T reflect.Type) []string {
 	requiredProps := findFieldsOfStruct(T)
-
-	relevantConfig := getRelevantRawConfigSection(rawConfig, family, handler)
 
 	superfluousProperties := make([]string, 0)
 
-	for prop := range relevantConfig {
+	for prop := range *componentConfig {
 		propertyDefined := false
 
 		if prop == "type" {
@@ -494,7 +550,11 @@ func VerifyOnlyRequiredConfigProps(rawConfig *map[string]interface{}, family, ha
 		}
 		if !propertyDefined {
 			superfluousProperties = append(superfluousProperties, prop)
-			confLog.WithField("property", prop).Warn("Configuration property configured but not defined in code (this property won't change anything, is it wrongly defined?)")
+			confLog.WithFields(logrus.Fields{
+				"family":   family,
+				"handler":  handler,
+				"property": prop,
+			}).Warn("Configuration property configured but not defined in code (this property won't change anything, is it wrongly defined?)")
 		}
 	}
 

--- a/config/testdata/configs/invalid
+++ b/config/testdata/configs/invalid
@@ -1,0 +1,8 @@
+{
+    "receivers": {
+        "bar": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    }
+}

--- a/config/testdata/configs/invalid.txt
+++ b/config/testdata/configs/invalid.txt
@@ -1,0 +1,8 @@
+{
+    "receivers": {
+        "bar": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    }
+}

--- a/config/testdata/configs/valid-one.json
+++ b/config/testdata/configs/valid-one.json
@@ -1,0 +1,8 @@
+{
+    "receivers": {
+        "bar": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    }
+}

--- a/config/testdata/configs/valid2.json
+++ b/config/testdata/configs/valid2.json
@@ -1,0 +1,19 @@
+{
+    "receivers": {
+        "foo": {
+            "type": "stdin",
+            "handler": "baz"
+        }
+    },
+    "handlers": {
+        "baz": {
+            "parser": "json",
+            "sender": "qux"
+        }
+    },
+    "senders": {
+        "qux": {
+            "type": "debug"
+        }
+    }
+}


### PR DESCRIPTION
Supersedes and closes #121.

This PR implements the same as #121 just in a different way. The same startup parameter exists, `-d`, which points to a directory of configuration files to be read. Skogul will read all json files in that directory and generate a configuration from this.

Superfluous config parameters have been moved out of secondPass and into Unmarshal for the specific types/interfaces.

Closes #82.