### PR TITLE
feat: Implement file sender

### DIFF
--- a/docs/examples/tester_to_file.json
+++ b/docs/examples/tester_to_file.json
@@ -1,0 +1,25 @@
+{
+  "receivers": {
+    "test": {
+      "type": "test",
+      "handler": "json",
+      "metrics": 100,
+      "values": 100,
+      "threads": 30
+    }
+  },
+  "handlers": {
+    "json": {
+      "parser": "json",
+      "transformers": [],
+      "sender": "file"
+    }
+  },
+  "senders": {
+    "file": {
+      "type": "file",
+      "path": "/tmp/skogul-out",
+      "append": true
+    }
+  }
+}

--- a/sender/auto.go
+++ b/sender/auto.go
@@ -84,6 +84,11 @@ func init() {
 		Help:  "Tries the senders provided in Next, in order. E.g.: if the first responds OK, the second will never get data. Useful for diverting traffic to alternate paths upon failure.",
 	})
 	Auto.Add(skogul.Module{
+		Name:  "file",
+		Alloc: func() interface{} { return &File{} },
+		Help:  "Writes metrics to file.",
+	})
+	Auto.Add(skogul.Module{
 		Name:  "forwardfail",
 		Alloc: func() interface{} { return &ForwardAndFail{} },
 		Help:  "Forwards metrics, but always returns failure. Useful in complex failure handling involving e.g. fallback sender, where it might be used to write log or stats on failure while still propogating a failure upward.",

--- a/sender/file.go
+++ b/sender/file.go
@@ -72,6 +72,7 @@ func (f *File) init() {
 	// Listening to a channel is blocking so we have
 	// to start the channel listening in a goroutine
 	// so that init() doesn't block.
+	f.c = make(chan []byte)
 	go f.startChan()
 
 	f.ok = true
@@ -81,7 +82,6 @@ func (f *File) startChan() error {
 	fileLog.Trace("Starting file writer channel")
 	// Making sure we close the file if this function exits
 	defer f.f.Close()
-	f.c = make(chan []byte)
 	for b := range f.c {
 		written, err := f.f.Write(append(b, newLineChar))
 		if err != nil {

--- a/sender/file.go
+++ b/sender/file.go
@@ -72,7 +72,7 @@ func (f *File) init() {
 	// Listening to a channel is blocking so we have
 	// to start the channel listening in a goroutine
 	// so that init() doesn't block.
-	f.c = make(chan []byte)
+	f.c = make(chan []byte, 50)
 	go f.startChan()
 
 	f.ok = true

--- a/sender/file.go
+++ b/sender/file.go
@@ -1,0 +1,126 @@
+/*
+ * skogul, file writer
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <Hakon.Solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package sender
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+
+	"github.com/telenornms/skogul"
+)
+
+var fileLog = skogul.Logger("sender", "file")
+
+const newLineChar byte = 10
+
+type File struct {
+	Path   string `doc:"Absolute path to file to write"`
+	Append bool   `doc:"Whether to append to the file when starting. If false, will empty file before starting writes. Default: false"`
+	ok     bool
+	once   sync.Once
+	f      *os.File
+	c      chan []byte
+}
+
+func (f *File) init() {
+	fileLog.Debug("Initializing File sender")
+
+	var err error
+	var file *os.File
+
+	// Open file for append-only if it already exists and config says to append
+	if finfo, err := os.Stat(f.Path); !os.IsNotExist(err) && f.Append {
+		fileLog.Trace("File exists, let's open it for writing")
+		file, err = os.OpenFile(f.Path, os.O_APPEND|os.O_WRONLY, finfo.Mode())
+	} else {
+		// Otherwise, create the file (which will truncate it if it already exists)
+		fileLog.Trace("Creating file since it doesn't exist or we don't want to append to it")
+		file, err = os.Create(f.Path)
+	}
+	if err != nil {
+		fileLog.WithError(err).Errorf("Failed to open '%s'", f.Path)
+		f.ok = false
+		return
+	}
+
+	// startChan() handles closing the file as this function returns
+	// and consequently would close the file
+	f.f = file
+
+	// Listening to a channel is blocking so we have
+	// to start the channel listening in a goroutine
+	// so that init() doesn't block.
+	go f.startChan()
+
+	f.ok = true
+}
+
+func (f *File) startChan() error {
+	fileLog.Trace("Starting file writer channel")
+	// Making sure we close the file if this function exits
+	defer f.f.Close()
+	f.c = make(chan []byte)
+	for b := range f.c {
+		written, err := f.f.Write(append(b, newLineChar))
+		if err != nil {
+			f.ok = false
+			fileLog.WithError(err).Errorf("Failed to write to file. Wrote %d of %d bytes", written, len(b))
+			return err
+		}
+		f.f.Sync()
+	}
+	fileLog.Warning("File writer chan closed, not handling any more writes!")
+	return nil
+}
+
+// Send receives a skogul container and writes it to file.
+func (f *File) Send(c *skogul.Container) error {
+	f.once.Do(func() {
+		f.init()
+	})
+
+	if !f.ok {
+		e := skogul.Error{Reason: "File sender not in OK state", Source: "file sender"}
+		fileLog.WithError(e).Error("Failied to initialize file sender, or an error occured in runtime")
+		return e
+	}
+
+	b, err := json.Marshal(*c)
+
+	if err != nil {
+		fileLog.WithError(err).Error("Failed to marshal container data to json")
+		return err
+	}
+
+	f.c <- b
+
+	return nil
+}
+
+// Verify checks that the configuration options are set appropriately
+func (f *File) Verify() error {
+	fileLog.Debug("Verified file sender")
+	return nil
+}

--- a/sender/file.go
+++ b/sender/file.go
@@ -78,7 +78,7 @@ func (f *File) init() {
 	f.ok = true
 }
 
-func (f *File) startChan() error {
+func (f *File) startChan() {
 	fileLog.Trace("Starting file writer channel")
 	// Making sure we close the file if this function exits
 	defer f.f.Close()
@@ -87,12 +87,10 @@ func (f *File) startChan() error {
 		if err != nil {
 			f.ok = false
 			fileLog.WithError(err).Errorf("Failed to write to file. Wrote %d of %d bytes", written, len(b))
-			return err
 		}
 		f.f.Sync()
 	}
 	fileLog.Warning("File writer chan closed, not handling any more writes!")
-	return nil
 }
 
 // Send receives a skogul container and writes it to file.

--- a/sender/file.go
+++ b/sender/file.go
@@ -119,6 +119,10 @@ func (f *File) Send(c *skogul.Container) error {
 
 // Verify checks that the configuration options are set appropriately
 func (f *File) Verify() error {
-	fileLog.Debug("Verified file sender")
+	if f.Path == "" {
+		err := skogul.Error{Reason: "Path name for file sender missing", Source: "file sender"}
+		fileLog.WithError(err).Error("Missing path to file for file sender")
+		return err
+	}
 	return nil
 }

--- a/sender/file_test.go
+++ b/sender/file_test.go
@@ -1,0 +1,142 @@
+/*
+ * skogul, file writer tests
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <Hakon.Solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package sender_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	skogul "github.com/telenornms/skogul"
+	sender "github.com/telenornms/skogul/sender"
+)
+
+func createConf() {
+
+}
+
+// createContainer is a simple helper func which
+// creates a skogul.Container with some data
+func createContainer() skogul.Container {
+	meta := make(map[string]interface{})
+	meta["foo"] = "bar"
+	data := make(map[string]interface{})
+	data["baz"] = "qux"
+
+	metric := skogul.Metric{
+		Metadata: meta,
+		Data:     data,
+	}
+	metrics := make([]*skogul.Metric, 0)
+	metrics = append(metrics, &metric)
+	return skogul.Container{
+		Metrics: metrics,
+	}
+}
+
+func TestWriteToNonExistingFile(t *testing.T) {
+	filename := "skogul-file-sender-nonexisting-file.txt"
+	tmpdir := os.TempDir()
+	path := path.Join(tmpdir, filename)
+
+	// Ensure file does not exist already
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		// Already exists..
+		// Let's assume it's safe to remove ?
+		os.Remove(path)
+	}
+
+	// Now let's initialize a config which writes to that file which does not exist
+	sender := &sender.File{
+		Path:   path,
+		Append: false,
+	}
+
+	c := createContainer()
+	sender.Send(&c)
+
+	// Since the write is done by a goroutine
+	// we have to make sure it is properly
+	// flushed before we try to read it back
+	time.Sleep(time.Second)
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	var j map[string]interface{}
+	err = json.Unmarshal(b, &j)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	// Assume that if we managed to read the file
+	// and unmarshal the contents to JSON
+	// the write succeeded.
+}
+
+func TestAppendToExistingFile(t *testing.T) {
+	filename := "skogul-file-sender-existing-file-append.txt"
+	path := path.Join(os.TempDir(), filename)
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	f.Write([]byte("some data\n"))
+	f.Sync()
+
+	time.Sleep(time.Second)
+
+	sender := &sender.File{
+		Path:   path,
+		Append: true,
+	}
+
+	c := createContainer()
+	sender.Send(&c)
+
+	// Since the write is done by a goroutine
+	// we have to make sure it is properly
+	// flushed before we try to read it back
+	time.Sleep(time.Second)
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	str := string(b)
+	if !strings.Contains(str, "some data") {
+		t.Errorf("Test file does not contain test string 'some data', was it overwritten? Contents: %s", str)
+	}
+}


### PR DESCRIPTION
Adds a file sender. The configuration options support truncating the file on startup, or leaving it as it is, as well as specifying a path to the file.

I have yet to write tests but I am a bit unsure of where to start in that regard. I'll scour the other senders and their tests to see if I can come up with something.