### PR TITLE
Promote parsers to fully fledged modules

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,7 +1,7 @@
 /*
  * skogul, common trivialities
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *
@@ -138,6 +138,13 @@ type HandlerRef struct {
 // It is used during configuration/transformer setup.
 type TransformerRef struct {
 	T    Transformer
+	Name string
+}
+
+// ParserRef is a string mapping to a Parser.
+// It is used during configuration setup.
+type ParserRef struct {
+	P    Parser
 	Name string
 }
 

--- a/config/help.go
+++ b/config/help.go
@@ -1,3 +1,25 @@
+/*
+ * skogul  config module help generation
+ *
+ * Copyright (c) 2019-2020 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
 package config
 
 import (
@@ -22,6 +44,7 @@ type Help struct {
 	Doc         string
 	Fields      map[string]FieldDoc
 	CustomTypes map[string]map[string]FieldDoc
+	AutoMake    bool
 }
 
 // HelpModule looks up help for a module in the specified module map. It
@@ -33,6 +56,7 @@ func HelpModule(mmap skogul.ModuleMap, mod string) (Help, error) {
 	mh := Help{}
 	mh.Name = mod
 	mh.Doc = mmap[mod].Help
+	mh.AutoMake = mmap[mod].AutoMake
 	for _, alias := range mmap[mod].Aliases {
 		mh.Aliases = fmt.Sprintf("%s %s", alias, mh.Aliases)
 	}

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -1,3 +1,26 @@
+/*
+ * skogul  config module help generation
+ *
+ * Copyright (c) 2019-2020 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
 package config_test
 
 import (
@@ -112,6 +135,112 @@ func TestByte_ok(t *testing.T) {
 		t.Errorf("Bytes() with bad data returned valid config.")
 	}
 
+}
+
+func TestDefaultModules(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("Byte() paniced")
+		}
+	}()
+	var okData []byte
+	okData = []byte(`
+{
+  "handlers": {
+    "plain": {
+      "parser": "json",
+      "sender": "debug",
+      "transformers": ["templater"]
+    }
+  },
+  "receivers": {
+    "http": {
+      "type": "http",
+      "handlers": {
+	      "/": "plain"
+      }
+    }
+  }
+}
+`)
+	c, err := config.Bytes(okData)
+	if err != nil {
+		t.Errorf("Bytes() failed: %v", err)
+	}
+	if c == nil {
+		t.Errorf("Bytes() returned nil config")
+	}
+}
+func TestUndefinedParser(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("Byte() paniced")
+		}
+	}()
+	var okData []byte
+	okData = []byte(`
+{
+  "handlers": {
+    "plain": {
+      "parser": "bondevik",
+      "sender": "debug",
+      "transformers": ["templater"]
+    }
+  },
+  "receivers": {
+    "http": {
+      "type": "http",
+      "handlers": {
+	      "/": "plain"
+      }
+    }
+  }
+}
+`)
+	_, err := config.Bytes(okData)
+	if err == nil {
+		t.Errorf("Bytes() didn't fail, despite undefined parser.")
+	}
+}
+
+func TestNamedParser(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("Byte() paniced")
+		}
+	}()
+	var okData []byte
+	okData = []byte(`
+{
+  "parsers": {
+    "jens": {
+      "type": "json"
+    }
+  },
+  "handlers": {
+    "plain": {
+      "parser": "jens",
+      "sender": "debug",
+      "transformers": ["templater"]
+    }
+  },
+  "receivers": {
+    "http": {
+      "type": "http",
+      "handlers": {
+	      "/": "plain"
+      }
+    }
+  }
+}
+`)
+	c, err := config.Bytes(okData)
+	if err != nil {
+		t.Errorf("Bytes() failed: %v", err)
+	}
+	if c == nil {
+		t.Errorf("Bytes() returned nil config")
+	}
 }
 
 func TestHelpModule(t *testing.T) {
@@ -407,6 +536,7 @@ func TestReadConfigWithoutSuperfluousParamsNoSuperfluousParams(t *testing.T) {
     },
     "handlers": {
       "bar": {
+	"parser": "json",
         "sender": "baz"
       }
     },

--- a/marshal.go
+++ b/marshal.go
@@ -1,7 +1,7 @@
 /*
  * skogul, marshaling functions
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *
@@ -45,6 +45,9 @@ var HandlerMap []*HandlerRef
 // TransformerMap keeps track of the named transformers.
 var TransformerMap []*TransformerRef
 
+// ParserMap keeps track of the named parsers.
+var ParserMap []*ParserRef
+
 /*
 UnmarshalJSON will unmarshal a sender reference by creating a
 SenderRef object and putting it on the SenderMap list. The
@@ -67,16 +70,6 @@ func (sr *SenderRef) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("\"%s\"", sr.Name)), nil
 }
 
-// MarshalJSON just returns the Name of the handler reference.
-func (hr *HandlerRef) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", hr.Name)), nil
-}
-
-// MarshalJSON just returns the Name of the transformer reference.
-func (tr *TransformerRef) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", tr.Name)), nil
-}
-
 // UnmarshalJSON will create an entry on the HandlerMap for the parsed
 // handler reference, so the real handler can be substituted later.
 func (hr *HandlerRef) UnmarshalJSON(b []byte) error {
@@ -90,6 +83,29 @@ func (hr *HandlerRef) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON just returns the Name of the handler reference.
+func (hr *HandlerRef) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", hr.Name)), nil
+}
+
+// UnmarshalJSON will create an entry on the ParserMap for the parsed
+// parser reference, so the real parser can be substituted later.
+func (pr *ParserRef) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	pr.Name = s
+	pr.P = nil
+	ParserMap = append(ParserMap, pr)
+	return nil
+}
+
+// MarshalJSON just returns the Name of the parser reference.
+func (pr *ParserRef) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", pr.Name)), nil
+}
+
 // UnmarshalJSON will create an entry on the TransformerMap for the parsed
 // transformer reference, so the real transformer can be substituted later.
 func (tr *TransformerRef) UnmarshalJSON(b []byte) error {
@@ -101,6 +117,11 @@ func (tr *TransformerRef) UnmarshalJSON(b []byte) error {
 	tr.T = nil
 	TransformerMap = append(TransformerMap, tr)
 	return nil
+}
+
+// MarshalJSON just returns the Name of the transformer reference.
+func (tr *TransformerRef) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", tr.Name)), nil
 }
 
 // MarshalJSON provides JSON marshalling for Duration

--- a/parser/auto.go
+++ b/parser/auto.go
@@ -1,0 +1,70 @@
+/*
+ * skogul, parser automation
+ *
+ * Copyright (c) 2019-2020 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package parser
+
+import (
+	"github.com/telenornms/skogul"
+)
+
+// Auto maps parser-names to parser implementation, used for auto
+// configuration.
+var Auto skogul.ModuleMap
+
+func init() {
+	Auto.Add(skogul.Module{
+		Name:     "skogul",
+		Aliases:  []string{"json"},
+		Alloc:    func() interface{} { return &JSON{} },
+		Help:     "Parses the standard Skogul JSON format.",
+		AutoMake: true,
+	})
+	Auto.Add(skogul.Module{
+		Name:     "rawjson",
+		Aliases:  []string{"jsonraw", "custom-json"},
+		Alloc:    func() interface{} { return &RawJSON{} },
+		Help:     "Parses any generic JSON data into a single metric which can then be potentially transformed into multiple metrics if need be.",
+		AutoMake: true,
+	})
+	Auto.Add(skogul.Module{
+		Name:     "influxdb",
+		Aliases:  []string{"influx"},
+		Alloc:    func() interface{} { return &InfluxDB{} },
+		Help:     "Parse InfluxDB line-protocol data",
+		AutoMake: true,
+	})
+	Auto.Add(skogul.Module{
+		Name:     "protobuf",
+		Aliases:  []string{"telemetry", "juniper"},
+		Alloc:    func() interface{} { return &ProtoBuf{} },
+		Help:     "Parse Juniper telemetry in the form of protocol buffers. Typicially combined with the UDP receiver.",
+		AutoMake: true,
+	})
+	Auto.Add(skogul.Module{
+		Name:     "mnr",
+		Aliases:  []string{"m&r"},
+		Alloc:    func() interface{} { return &MNR{} },
+		Help:     "Parse M&R internal data",
+		AutoMake: true,
+	})
+}

--- a/sender/auto.go
+++ b/sender/auto.go
@@ -1,7 +1,7 @@
 /*
  * skogul, sender automation
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *
@@ -51,9 +51,11 @@ func init() {
 		Help:    "Accepts metrics, counts them and passes them on. Then emits statistics to the Stats-handler on an interval.",
 	})
 	Auto.Add(skogul.Module{
-		Name:  "debug",
-		Alloc: func() interface{} { return &Debug{} },
-		Help:  "Prints received metrics to stdout.",
+		Name:     "debug",
+		Aliases:  []string{"print"},
+		Alloc:    func() interface{} { return &Debug{} },
+		Help:     "Prints received metrics to stdout.",
+		AutoMake: true,
 	})
 	Auto.Add(skogul.Module{
 		Name:    "detacher",

--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -1,3 +1,25 @@
+/*
+ * skogul, transformer automation
+ *
+ * Copyright (c) 2019-2020 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
 package transformer
 
 import (
@@ -9,10 +31,11 @@ var Auto skogul.ModuleMap
 
 func init() {
 	Auto.Add(skogul.Module{
-		Name:    "templater",
-		Aliases: []string{"template", "templating"},
-		Alloc:   func() interface{} { return &Templater{} },
-		Help:    "Executes metric templating. See separate documentationf or how skogul templating works.",
+		Name:     "templater",
+		Aliases:  []string{"template", "templating"},
+		Alloc:    func() interface{} { return &Templater{} },
+		Help:     "Executes metric templating. See separate documentationf or how skogul templating works.",
+		AutoMake: true,
 	})
 	Auto.Add(skogul.Module{
 		Name:    "metadata",


### PR DESCRIPTION
This ALSO introduces the concept of "automake" modules, which are
modules that do not need to be explicitly defined in their relevant
configuration section. This will let us continue to refer to parsers as
just "json" without having to explicitly define the json-parser, which
doesn't require any options, but gives us the option to do so.

In addition to most parsers, this has been enabled for the debug-sender
and the templater transformer.

The rest of this patch is mostly just a matter of replacing the
hardcoded resolveParser() with the resolveParsers() function that is
similar to resolveSenders, etc, and the required scaffolding to support
that with various Marshal/Unmarshal functions.

All tests pass.

Fixes #135 #136 

NOTE: This introduces one potentially breaking change: In the past, you
could omit the parser from the handler section and it would silently
default to json. This is no longer allowed and a parser MUST be
explicitly configured for every handler. Now that we have a decent
amount of parsers, this seems justified.