### PR TITLE
Chore: Update a ton of copyright-headers

### DIFF
--- a/build/ischanged.sh
+++ b/build/ischanged.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if a file is changed this year and if the copyright-header reflects
+# it. Use in combination with find.
+
+YEAR=$(date +%Y)
+if [ $(git log --since=${YEAR}-01-01 --oneline "$1" | wc -l) -gt 0 ]; then
+	if grep -q "Copyright.*${YEAR}" $1; then
+		if [ ! -z "${VERBOSE}" ]; then
+			echo "$1 Updated, but correct header";
+		fi
+	else
+		echo "$1 Updated, missing copyright year"
+	fi
+else
+	if [ ! -z "${VERBOSE}" ]; then
+		echo "$1 Not updated"
+	fi
+fi
+
+if ! grep Copyright $1 -q; then
+	echo $1 missing Copyright-header all together
+fi

--- a/common.go
+++ b/common.go
@@ -4,6 +4,7 @@
  * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/common_test.go
+++ b/common_test.go
@@ -1,9 +1,10 @@
 /*
  * skogul, tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/config/example_config_test.go
+++ b/config/example_config_test.go
@@ -1,3 +1,26 @@
+/*
+ * skogul, config tests
+ *
+ * Copyright (c) 2020 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
 package config_test
 
 import (

--- a/data.go
+++ b/data.go
@@ -1,7 +1,7 @@
 /*
  * skogul, core data structures
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/data_test.go
+++ b/data_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, data structure tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 /*
  * skogul, documentation
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -4,6 +4,7 @@
  * Copyright (c) 2019 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/marshal.go
+++ b/marshal.go
@@ -4,6 +4,7 @@
  * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/parser/influxdb.go
+++ b/parser/influxdb.go
@@ -1,3 +1,26 @@
+/*
+ * skogul, influxdb parser
+ *
+ * Copyright (c) 2020 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
 package parser
 
 import (

--- a/parser/influxdb_test.go
+++ b/parser/influxdb_test.go
@@ -1,3 +1,26 @@
+/*
+ * skogul, influxdb parser tests
+ *
+ * Copyright (c) 2019-2020 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
 package parser_test
 
 import (

--- a/parser/json.go
+++ b/parser/json.go
@@ -1,9 +1,10 @@
 /*
  * skogul, json parser
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -1,9 +1,10 @@
 /*
  * skogul, test json parser
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/parser/protobuf_test.go
+++ b/parser/protobuf_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, test protobuf parser
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/receiver/common_test.go
+++ b/receiver/common_test.go
@@ -1,3 +1,26 @@
+/*
+ * skogul, common receover test code
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
 package receiver_test
 
 import (

--- a/receiver/examples_test.go
+++ b/receiver/examples_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, receiver examples
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/receiver/http.go
+++ b/receiver/http.go
@@ -4,6 +4,7 @@
  * Copyright (c) 2019 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/receiver/http_test.go
+++ b/receiver/http_test.go
@@ -4,6 +4,7 @@
  * Copyright (c) 2019 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/receiver/mqtt.go
+++ b/receiver/mqtt.go
@@ -1,9 +1,10 @@
 /*
  * skogul, mqtt-receiver
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/receiver/tester_test.go
+++ b/receiver/tester_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, test receiver tests (... I know)
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/receiver/udp.go
+++ b/receiver/udp.go
@@ -1,7 +1,7 @@
 /*
  * skogul, udp message receiver
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/receiver/udp_test.go
+++ b/receiver/udp_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, udp receiver tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/sender/backoff_test.go
+++ b/sender/backoff_test.go
@@ -1,3 +1,25 @@
+/*
+ * skogul, backoff sender tests
+ *
+ * Copyright (c) 2019 Telenor Norge AS
+ * Author(s):
+ *  - Kristian Lyngstøl <kly@kly.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
 package sender_test
 
 import (

--- a/sender/complex_test.go
+++ b/sender/complex_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, complex sender tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/sender/counter_test.go
+++ b/sender/counter_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, counter tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/sender/file.go
+++ b/sender/file.go
@@ -1,7 +1,7 @@
 /*
  * skogul, file writer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Håkon Solbjørg <Hakon.Solbjorg@telenor.com>
  *

--- a/sender/file_test.go
+++ b/sender/file_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, file writer tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Håkon Solbjørg <Hakon.Solbjorg@telenor.com>
  *

--- a/sender/influxdb.go
+++ b/sender/influxdb.go
@@ -1,9 +1,10 @@
 /*
  * skogul, influxdb writer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/sender/mqtt.go
+++ b/sender/mqtt.go
@@ -4,6 +4,7 @@
  * Copyright (c) 2019 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/timer.go
+++ b/timer.go
@@ -1,7 +1,7 @@
 /*
  * skogul, time syncer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/timer_test.go
+++ b/timer_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, timer benchmarks
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/transformer/metadata.go
+++ b/transformer/metadata.go
@@ -1,9 +1,10 @@
 /*
  * skogul, metadata transformer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/transformer/metadata_test.go
+++ b/transformer/metadata_test.go
@@ -1,9 +1,10 @@
 /*
  * skogul, templating tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/transformer/split.go
+++ b/transformer/split.go
@@ -1,7 +1,7 @@
 /*
  * skogul, split transformer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *

--- a/transformer/split_test.go
+++ b/transformer/split_test.go
@@ -1,7 +1,7 @@
 /*
  * skogul, split transformer tests
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *

--- a/transformer/switch.go
+++ b/transformer/switch.go
@@ -1,7 +1,7 @@
 /*
  * skogul, switch transformer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *

--- a/transformer/template.go
+++ b/transformer/template.go
@@ -1,7 +1,7 @@
 /*
  * skogul, template transformer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *

--- a/transformer/timestamp.go
+++ b/transformer/timestamp.go
@@ -1,7 +1,7 @@
 /*
  * skogul, timestamp transformer
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2020 Telenor Norge AS
  * Author(s):
  *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
  *


### PR DESCRIPTION
I tried to verify that they have actually been updated in 2020, but I
figure it's no disaster if we miss. I also added Håkon to files where
git-log told me he had more than a line or two of edits, but that might
not be fool proof.