### PR TITLE
Feat: Structured Data (as per RFC5424) parser

### DIFF
--- a/parser/auto.go
+++ b/parser/auto.go
@@ -67,4 +67,11 @@ func init() {
 		Help:     "Parse M&R internal data",
 		AutoMake: true,
 	})
+	Auto.Add(skogul.Module{
+		Name:     "structured_data",
+		Aliases:  []string{},
+		Alloc:    func() interface{} { return &StructuredData{} },
+		Help:     "Parse structured data as specified in RFC5424",
+		AutoMake: true,
+	})
 }

--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -1,0 +1,135 @@
+/*
+ * skogul, rfc 5424 structured data parser
+ *
+ * Copyright (c) 2020 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+
+	"github.com/telenornms/skogul"
+)
+
+var sdLog = skogul.Logger("parser", "structured_data")
+
+// StructuredData supports parsing RFC5424 structured data through the Parse() function
+// Note: This does not parse a full syslog message.
+type StructuredData struct{}
+
+// Parse converts RFC5424 Structured Data data into a skogul Container
+func (sd *StructuredData) Parse(bytes []byte) (*skogul.Container, error) {
+	metrics, err := sd.parseStructuredData(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &skogul.Container{
+		Metrics: metrics,
+	}, nil
+}
+
+// mnrParseData takes the raw input and parses it
+// this takes care of splitting input on newlines etc
+func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, error) {
+	lines := bytes.Split(data, []byte("\n"))
+
+	metrics := make([]*skogul.Metric, 0)
+
+	timestamp := skogul.Now()
+
+	for _, l := range lines {
+		line := bytes.TrimSpace(l)
+		if len(line) <= 2 {
+			// Skip empty lines and lines without wrapping []
+			continue
+		}
+
+		kvScanner := bufio.NewScanner(bytes.NewReader(line[1 : len(line)-1])) // trim leading [ and trailing ]
+		// ToDo: Support Example 2 from https://tools.ietf.org/html/rfc5424#section-6.3.5
+		kvScanner.Split(splitKeyValuePairs)
+
+		// First entry in the line is a single value, not a key/value pair
+		// Extract it, and store it.
+		ok := kvScanner.Scan()
+		if !ok {
+			sdLog.Warning("Failed to parse structured data line")
+			continue
+		}
+		structuredDataID := kvScanner.Text()
+
+		metadata := make(map[string]interface{})
+		metadata["sd-id"] = structuredDataID
+
+		data := make(map[string]interface{})
+		for {
+			canContinue := kvScanner.Scan()
+
+			tag := strings.Trim(kvScanner.Text(), "\u0000")
+			tagValue := strings.SplitN(tag, "=", 2)
+
+			if len(tagValue) != 2 {
+				break
+			}
+
+			paramName := tagValue[0]
+			paramValue := tagValue[1][1 : len(tagValue[1])-1] // remove leading and trailing "s
+
+			// @ToDo: Support multiple paramName with different paramValue
+			// if the value already exists, replace it with an array ?
+
+			data[paramName] = paramValue
+			sdLog.WithField("tag", paramName).WithField("val", paramValue).Debug("Got :)")
+
+			if !canContinue {
+				break
+			}
+		}
+		metrics = append(metrics, &skogul.Metric{
+			Time:     &timestamp,
+			Data:     data,
+			Metadata: metadata,
+		})
+	}
+	if len(metrics) == 0 {
+		sdLog.WithField("lines", len(lines)).Warnf("RFC5424/Structured Data parser failed to parse any of the %d lines", len(lines))
+		return nil, skogul.Error{Reason: "Failed to parse RFC5424 lines", Source: "structured_data-parser"}
+	}
+	return metrics, nil
+}
+
+// splitKeyValuePairs splits a section (tag key=value pairs or field key=value pairs)
+// into key=value pairs, honoring escape rules as per the influx line protocol.
+// A key=value pair is split on a non-escaped space.
+func splitKeyValuePairs(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	fieldWidth, newData := influxLineParser(data, ' ', true)
+
+	returnChars := len(newData)
+
+	if returnChars == len(data) {
+		// EOF, return with what we have left
+		return returnChars, newData[:returnChars], nil
+	}
+
+	// Skip the trailing comma between each key=value pair, but still advance counter
+	return fieldWidth, newData[:returnChars], nil
+}

--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -77,6 +77,9 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 			tagValue := strings.SplitN(tag, "=", 2)
 
 			if len(tagValue) == 1 {
+				if strings.TrimSpace(tagValue[0]) == "" {
+					return nil, skogul.Error{Reason: "Got invalid data in the middle of a structured data line", Source: "structured_data-parser"}
+				}
 				if metric != nil {
 					metrics = append(metrics, metric)
 				}

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -52,6 +52,7 @@ func TestStructuredDataParseExample1(t *testing.T) {
 }
 
 func TestStructuredDataParseExample2(t *testing.T) {
+	t.Skip("skipping unfinished test")
 	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
 
 	p := parser.StructuredData{}
@@ -81,6 +82,7 @@ func TestStructuredDataParseExample2(t *testing.T) {
 }
 
 func TestStructuredDataParseExample3Fails(t *testing.T) {
+	t.Skip("skipping unfinished test")
 	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] [examplePriority@32473 class="high"]`)
 	p := parser.StructuredData{}
 
@@ -91,6 +93,7 @@ func TestStructuredDataParseExample3Fails(t *testing.T) {
 }
 
 func TestStructuredDataParseExample4Fails(t *testing.T) {
+	t.Skip("skipping unfinished test")
 	b := []byte(`[ exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
 	p := parser.StructuredData{}
 

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -1,0 +1,101 @@
+/*
+ * skogul, rfc 5424 structured data parser
+ *
+ * Copyright (c) 2020 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/telenornms/skogul/parser"
+)
+
+func TestStructuredDataParseExample1(t *testing.T) {
+	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]`)
+
+	p := parser.StructuredData{}
+
+	c, err := p.Parse(b)
+	if err != nil {
+		t.Error("Failed to parse valid format")
+		return
+	}
+
+	sdID := "exampleSDID@32473"
+	if c.Metrics[0].Metadata["sd-id"] != sdID {
+		t.Errorf("Expected SD-ID of '%s', got '%s'", sdID, c.Metrics[0].Metadata["sd-id"])
+	}
+
+	data := c.Metrics[0].Data
+	if data["iut"] != "3" || data["eventSource"] != "Application" || data["eventID"] != "1011" {
+		t.Error("Failed to parse one or more params from the structured data")
+	}
+}
+
+func TestStructuredDataParseExample2(t *testing.T) {
+	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
+
+	p := parser.StructuredData{}
+
+	c, err := p.Parse(b)
+	if err != nil {
+		t.Error("Failed to parse valid format")
+		return
+	}
+
+	sdID := "exampleSDID@32473"
+	if c.Metrics[0].Metadata["sd-id"] != sdID {
+		t.Errorf("Expected SD-ID of '%s', got '%s'", sdID, c.Metrics[0].Metadata["sd-id"])
+	}
+
+	data := c.Metrics[0].Data
+	expected := make(map[string]interface{})
+	expected["iut"] = "3"
+	expected["eventSource"] = "Application"
+	expected["eventID"] = "1011"
+	expected["class"] = "high"
+	for k, v := range expected {
+		if data[k] != expected[k] {
+			t.Errorf("Expected '%s' to be '%s', got '%s'", k, v, data[k])
+		}
+	}
+}
+
+func TestStructuredDataParseExample3Fails(t *testing.T) {
+	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] [examplePriority@32473 class="high"]`)
+	p := parser.StructuredData{}
+
+	if _, err := p.Parse(b); err == nil {
+		t.Error("Expected parser to fail for invalid format")
+		return
+	}
+}
+
+func TestStructuredDataParseExample4Fails(t *testing.T) {
+	b := []byte(`[ exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
+	p := parser.StructuredData{}
+
+	if _, err := p.Parse(b); err == nil {
+		t.Error("Expected parser to fail for invalid format")
+		return
+	}
+}

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -52,7 +52,6 @@ func TestStructuredDataParseExample1(t *testing.T) {
 }
 
 func TestStructuredDataParseExample2(t *testing.T) {
-	t.Skip("skipping unfinished test")
 	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
 
 	p := parser.StructuredData{}
@@ -73,11 +72,13 @@ func TestStructuredDataParseExample2(t *testing.T) {
 	expected["iut"] = "3"
 	expected["eventSource"] = "Application"
 	expected["eventID"] = "1011"
-	expected["class"] = "high"
 	for k, v := range expected {
 		if data[k] != expected[k] {
 			t.Errorf("Expected '%s' to be '%s', got '%s'", k, v, data[k])
 		}
+	}
+	if c.Metrics[1].Data["class"] != "high" {
+		t.Errorf("Expected '%s' to be '%s', got '%s'", "class", "high", c.Metrics[1].Data["class"])
 	}
 }
 

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -83,18 +83,16 @@ func TestStructuredDataParseExample2(t *testing.T) {
 }
 
 func TestStructuredDataParseExample3Fails(t *testing.T) {
-	t.Skip("skipping unfinished test")
 	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] [examplePriority@32473 class="high"]`)
 	p := parser.StructuredData{}
 
-	if _, err := p.Parse(b); err == nil {
-		t.Error("Expected parser to fail for invalid format")
+	if c, err := p.Parse(b); err == nil {
+		t.Errorf("Expected parser to fail for invalid format, got\n%+v", c)
 		return
 	}
 }
 
 func TestStructuredDataParseExample4Fails(t *testing.T) {
-	t.Skip("skipping unfinished test")
 	b := []byte(`[ exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
 	p := parser.StructuredData{}
 

--- a/parser/testdata/structured_data.txt
+++ b/parser/testdata/structured_data.txt
@@ -1,0 +1,2 @@
+[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
+[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]


### PR DESCRIPTION
Pretty similar to other key-value parsers. Not feature-complete, though, but I'm not sure how many of the features we need. It'll be easier to see what's missing when we get some mileage on this parser too.

One remaining task I think should be an "invalid format" check, namely examples 3 and 4 as specified in the test cases. Otherwise we could end up with unspecified behaviour. I'll have a look at that before merge.