### PR TITLE
feat: Add parse transformer

### DIFF
--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -50,6 +50,12 @@ func init() {
 		Help:    "Enforces custom-rules for data fields of metrics.",
 	})
 	Auto.Add(skogul.Module{
+		Name:    "parse",
+		Aliases: []string{},
+		Alloc:   func() interface{} { return &Parse{} },
+		Help:    "Parses a metric using a skogul parser",
+	})
+	Auto.Add(skogul.Module{
 		Name:    "split",
 		Aliases: []string{},
 		Alloc:   func() interface{} { return &Split{} },

--- a/transformer/parse.go
+++ b/transformer/parse.go
@@ -1,3 +1,26 @@
+/*
+ * skogul, mnr parser
+ *
+ * Copyright (c) 2020 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
 package transformer
 
 import (

--- a/transformer/parse.go
+++ b/transformer/parse.go
@@ -1,0 +1,123 @@
+package transformer
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/parser"
+)
+
+var parseLog = skogul.Logger("transformer", "parser")
+
+type Parse struct {
+	Parser              string `doc:"Name of skogul parser to use. Note: has to be auto-initialisable."` // Feature request: Re-use parser unmarshal logic here
+	Source              string `doc:"Name of data field to apply parser to"`
+	Destination         string `doc:"Field to create with the parsed data (default: [Source]_data)"`
+	DestinationMetadata string `doc:"Field to create with the parsed metadata (default: [Source]_metadata)"`
+	Keep                bool   `doc:"Keep the unparsed value (default: false)"`
+	Append              bool   `doc:"Insert the values directly in the existing container, instead of creating new fields (destination and destination_metadata). (default: false)"`
+	once                sync.Once
+	parser              skogul.Parser
+	ok                  bool
+}
+
+func (p *Parse) init() {
+	p.ok = false
+	if p.Destination == "" {
+		p.Destination = fmt.Sprintf("%s_data", p.Source)
+	}
+	if p.DestinationMetadata == "" {
+		p.DestinationMetadata = fmt.Sprintf("%s_metadata", p.Source)
+	}
+
+	parseLog.Debug("Trying to find parser to initialise")
+	for k, pars := range parser.Auto {
+		if strings.ToLower(k) == strings.ToLower(p.Parser) {
+			parseLog.Debugf("Found parser '%s', using it", k)
+			p.parser = pars.Alloc().(skogul.Parser)
+			p.ok = true
+			break
+		}
+	}
+	if p.parser == nil {
+		parseLog.Errorf("Failed to find parser with name '%s'", p.Parser)
+		p.ok = false
+		return
+	}
+}
+
+func (p *Parse) Transform(c *skogul.Container) error {
+	p.once.Do(func() {
+		p.init()
+	})
+
+	if !p.ok {
+		return skogul.Error{Reason: "Parser transformer not initialized", Source: "transformer-parser"}
+	}
+
+	for i, metric := range c.Metrics {
+		val, ok := metric.Data[p.Source].(string)
+		if !ok {
+			parseLog.Error("Failed to cast value to string")
+			continue
+		}
+		b := []byte(val)
+		parsed, err := p.parse(b)
+		if err != nil {
+			return err
+		}
+		if len(parsed.Metrics) == 0 {
+			return skogul.Error{Reason: "Parsed 0 metrics", Source: "transformer-parser"}
+		}
+
+		if !p.Keep {
+			delete(c.Metrics[i].Data, p.Source)
+		}
+
+		if p.Append {
+			// Insert directly into existing container
+			for field, val := range parsed.Metrics[0].Metadata {
+				c.Metrics[i].Metadata[field] = val
+			}
+			for field, val := range parsed.Metrics[0].Data {
+				c.Metrics[i].Data[field] = val
+			}
+		} else {
+			// Add new fields
+			data := make(map[string]interface{})
+			metadata := make(map[string]interface{})
+
+			for field, val := range parsed.Metrics[0].Metadata {
+				metadata[field] = val
+			}
+			for field, val := range parsed.Metrics[0].Data {
+				data[field] = val
+			}
+			c.Metrics[i].Data[p.DestinationMetadata] = metadata
+			c.Metrics[i].Data[p.Destination] = data
+		}
+	}
+	return nil
+}
+
+func (p *Parse) parse(b []byte) (*skogul.Container, error) {
+
+	parsed, err := p.parser.Parse(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsed, nil
+}
+
+func (p *Parse) Verify() error {
+	if p.Source == "" {
+		return skogul.Error{Reason: "Missing source field", Source: "transformer-parser"}
+	}
+	if (p.Destination != "" || p.DestinationMetadata != "") && p.Append {
+		parseLog.Warn("Destination or DestinationMetadata configured at the same time as Append - Append takes precedence, and Destination(Metadata) will be ignored.")
+	}
+	return nil
+}

--- a/transformer/parse_test.go
+++ b/transformer/parse_test.go
@@ -1,0 +1,118 @@
+/*
+ * skogul, mnr parser
+ *
+ * Copyright (c) 2020 Telenor Norge AS
+ * Author(s):
+ *  - Håkon Solbjørg <hakon.solbjorg@telenor.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package transformer_test
+
+import (
+	"testing"
+
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/parser"
+	"github.com/telenornms/skogul/transformer"
+)
+
+func TestParseTransformer(t *testing.T) {
+	b := []byte(`{"metrics":[{
+        "time": "2020-01-01T13:33:37Z",
+        "metadata": {
+            "foo": "bar"
+        },
+        "data": {
+            "influxql": "measurement tag=name field=name 1"
+        }
+    }]}`)
+
+	j := parser.JSON{}
+	c, err := j.Parse(b)
+	if err != nil {
+		t.Errorf("Failed to parse container")
+		return
+	}
+
+	parserTransformer := transformer.Parse{
+		Source: "influxql",
+		Parser: skogul.ParserRef{
+			P:    parser.InfluxDB{},
+			Name: "influx",
+		},
+		Keep: true,
+	}
+
+	if err := parserTransformer.Transform(c); err != nil {
+		t.Errorf("Failed to run parser transformer on container")
+		return
+	}
+
+	data := c.Metrics[0].Data["influxql_data"].(map[string]interface{})
+	if data["field"] != "name" {
+		t.Errorf("Expected to find 'name' for 'influxql'.'field' in container after running parser")
+	}
+	if c.Metrics[0].Data["influxql"] != "measurement tag=name field=name 1" {
+		t.Error("Expected to still find the source field for the data to parse in the data")
+	}
+}
+
+func TestParseTransformerAppend(t *testing.T) {
+	b := []byte(`{"metrics":[{
+        "time": "2020-01-01T13:33:37Z",
+        "metadata": {
+            "foo": "bar"
+        },
+        "data": {
+            "some_field": "foo",
+            "influxql": "measurement tag=name field=name 1"
+        }
+    }]}`)
+
+	j := parser.JSON{}
+	c, err := j.Parse(b)
+	if err != nil {
+		t.Errorf("Failed to parse container")
+		return
+	}
+
+	parserTransformer := transformer.Parse{
+		Source: "influxql",
+		Parser: skogul.ParserRef{
+			P:    parser.InfluxDB{},
+			Name: "influx",
+		},
+		Append: true,
+		Keep:   false,
+	}
+
+	if err := parserTransformer.Transform(c); err != nil {
+		t.Errorf("Failed to run parser transformer on container")
+		return
+	}
+
+	if c.Metrics[0].Data["field"] != "name" {
+		t.Errorf("Expected to find 'name' for 'field' in container after running parser")
+	}
+	if c.Metrics[0].Data["some_field"] != "foo" {
+		t.Error("Expected to find 'foo' for 'some_field' in container data after running parser with append")
+	}
+	if c.Metrics[0].Data["influxql"] == "measurement tag=name field=name 1" {
+		t.Error("Expected the 'influxql' field to be removed from the container when Keep: false")
+	}
+}


### PR DESCRIPTION
The parse transformer is a transformer which supports specifying a
parser to use for a specific source field, parsing that field using a
skogul parser.

~~Note: This does not support using a parser defined in "parsers". I'm thinking this should be supported, but could perhaps be left out for this first release?~~