### PR TITLE
feat: Add a target for releasing skogul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ covergui:
 	@echo 💡 Generating HTML coverage report and opening browser
 	@go tool cover -html coverage.out
 
+release:
+	@git tag -a $$(head -n 1 docs/NEWS)
+
 clean:
 	@echo 💩Cleaning up
 	@-rm -fr dist
@@ -130,4 +133,4 @@ help:
 	@echo " - fmtfix - Runs gofmt -d -s -w, excluding generated code (e.g.: fix formating)"
 	@echo " - covergui - Run tests, track test coverage and open coverage analysis in browser"
 
-.PHONY: clean test bench help install rpm
+.PHONY: clean test bench help install rpm release


### PR DESCRIPTION
Mainly inspired by the fact that we probably should use `-a` when
tagging releases, but this way we'll have a common way of doing releases
locally. Maybe we could add a default release message too, such as
`release version v{version}` and/or the relevant section of docs/NEWS.