### PR TITLE
Fix/structured data empty data

### DIFF
--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -81,7 +81,12 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 					return nil, skogul.Error{Reason: "Got invalid data in the middle of a structured data line", Source: "structured_data-parser"}
 				}
 				if metric != nil {
-					metrics = append(metrics, metric)
+					if len(metric.Data) > 0 {
+						metrics = append(metrics, metric)
+					} else {
+						sdLog.Tracef("NOT Creating new metric because existing is empty, metric: %v, line:'%s'", metric, string(line))
+						break
+					}
 				}
 				metric = &skogul.Metric{
 					Time:     &timestamp,
@@ -107,6 +112,8 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 			}
 		}
 		if metric != nil {
+			// Note: We add metrics even if they have no data fields.
+			// Intended from sender or misconfigured sender?
 			metrics = append(metrics, metric)
 		}
 	}

--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -125,8 +125,6 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 }
 
 // splitKeyValuePairs splits a section (tag key=value pairs or field key=value pairs)
-// into key=value pairs, honoring escape rules as per the influx line protocol.
-// A key=value pair is split on a non-escaped space.
 func splitKeyValuePairs(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	fieldWidth, newData := structuredDataParser(data, true)
 
@@ -141,11 +139,7 @@ func splitKeyValuePairs(data []byte, atEOF bool) (advance int, token []byte, err
 	return fieldWidth, newData[:returnChars], nil
 }
 
-// influxLineParser parses part of an influxdb line protocol line and tells the
-// calling scanner how far it should advance (pretty similar to the splitFunc API).
-// The character to split on is passed to the function, and would usually be
-// a space or a comma character, as those are what's used to split
-// the influx line protocol section or key=value pair from each other.
+// struturedDataParser parses a structured data-line.
 // A boolean flag decides whether or not escape characters should remain in the output
 // or have their prepending escape character removed.
 func structuredDataParser(data []byte, removeEscapedCharsFromResult bool) (int, []byte) {

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -101,3 +101,18 @@ func TestStructuredDataParseExample4Fails(t *testing.T) {
 		return
 	}
 }
+
+func TestStructuredDataParseNoContentResultsInOneMetric(t *testing.T) {
+	b := []byte(`[exampleSDID@32473]`)
+	p := parser.StructuredData{}
+
+	c, err := p.Parse(b)
+	if err != nil {
+		t.Error("Failed to parse data")
+		return
+	}
+
+	if len(c.Metrics) != 1 {
+		t.Errorf("Expected SD-ID-only metric to return 1 metric, got %d", len(c.Metrics))
+	}
+}

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -24,6 +24,7 @@
 package parser_test
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/telenornms/skogul/parser"
@@ -114,5 +115,24 @@ func TestStructuredDataParseNoContentResultsInOneMetric(t *testing.T) {
 
 	if len(c.Metrics) != 1 {
 		t.Errorf("Expected SD-ID-only metric to return 1 metric, got %d", len(c.Metrics))
+	}
+}
+
+func TestStructuredDataOnDataset(t *testing.T) {
+	b, err := ioutil.ReadFile("./testdata/structured_data.txt")
+	if err != nil {
+		t.Errorf("Failed to read test data file: %v", err)
+		return
+	}
+
+	p := parser.StructuredData{}
+	container, err := p.Parse(b)
+	if err != nil {
+		t.Errorf("Structured data parser errored on parsing data: %s", err)
+		return
+	}
+	if len(container.Metrics) == 0 {
+		t.Error("Expected metrics from parsing structured data test data set, got 0")
+		return
 	}
 }

--- a/parser/testdata/structured_data.txt
+++ b/parser/testdata/structured_data.txt
@@ -1,2 +1,3 @@
 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]
+[exampleSDID@32473]


### PR DESCRIPTION
Apparently, sending `[example@1234]` is perfectly valid. This would cause the parser to go into an infinite loop. This simple fix will abort continuing parsing if there are no data fields in the received data. Not sure if it's the best approach, but I'll think about it.