### PR TITLE
upd: make UDP packet size configurable #148

### DIFF
--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -362,7 +362,8 @@ receiver. An example configuration::
 	      "udp": {
 		"type": "udp",
 		"address": ":5015",
-		"handler": "protobuf"
+		"handler": "protobuf",
+		"packetsize": 9000
 	      }
 	  },
 	  "handlers": {
@@ -390,7 +391,8 @@ An example that writes to postgres::
 	      "udp": {
 		"type": "udp",
 		"address": ":5015",
-		"handler": "protobuf"
+		"handler": "protobuf",
+		"packetsize": 9000
 	      }
 	  },
 	  "handlers": {

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -399,7 +399,8 @@ func Test_syntaxError(t *testing.T) {
       "udp": {
         "type": "udp",
         "address": "[::1]:5015",
-        "handler": "protobuf"
+        "handler": "protobuf",
+		"packetsize": 9000
       }
     },
     "handlers": {
@@ -457,6 +458,7 @@ func TestFindSuperfluousReceiverConfigPropertiesFromFullConfig(t *testing.T) {
 		"foo": {
 		  "type": "udp",
 		  "address": "[::1]:5015",
+		  "packetsize": 9000,
 		  "superfluousField": "this is not needed"
 		}
 	  }
@@ -487,6 +489,7 @@ func TestFindSuperfluousReceiverConfigProperties(t *testing.T) {
 	rawConfig := []byte(`{
 		"type": "udp",
 		"address": "[::1]:5015",
+		"packetsize": 9000,
 		"superfluousField": "this is not needed"
 	}`)
 
@@ -514,6 +517,7 @@ func TestBytesWorksWithSuperfluousReceiverConfigProperties(t *testing.T) {
 		"foo": {
 		  "type": "udp",
 		  "address": "[::1]:5015",
+			"packetsize": 9000,
 		  "superfluousField": "this is not needed"
 		}
 	  }

--- a/docs/examples/udp-protobuf-transform.json
+++ b/docs/examples/udp-protobuf-transform.json
@@ -3,7 +3,8 @@
     "udp": {
       "type": "udp",
       "address": "[::1]:5015",
-      "handler": "protobuf"
+      "handler": "protobuf",
+      "packetsize": 9000
     }
   },
   "handlers": {

--- a/docs/telemetry.rst
+++ b/docs/telemetry.rst
@@ -81,7 +81,8 @@ Basic reception of Telemetry is very straight forward::
          "udp": {
            "type": "udp",
            "address": ":1234",
-           "handler": "protobuf"
+           "handler": "protobuf",
+           "packetsize": 9000
          }
      },
      "handlers": {
@@ -109,7 +110,8 @@ set of transformers to "flatten" the data and send it to influxdb::
       "udp": {
         "type": "udp",
           "address": ":1234",
-          "handler": "protobuf"
+          "handler": "protobuf",
+          "packetsize": 9000
       }
     },
     "handlers": {

--- a/receiver/udp.go
+++ b/receiver/udp.go
@@ -29,6 +29,7 @@ import (
 
 	"errors"
 	"github.com/telenornms/skogul"
+	"strconv"
 )
 
 const (
@@ -63,7 +64,7 @@ func (ud *UDP) process() {
 // never returns.
 func (ud *UDP) Start() error {
 	if ud.PacketSize < 0 || ud.PacketSize > UDP_MAX_READ_SIZE {
-		return errors.New("invalid udp packet size, maximum udp read size is between 0 and " + string(UDP_MAX_READ_SIZE))
+		return errors.New("invalid udp packet size, maximum udp read size is between 0 and " + strconv.Itoa(UDP_MAX_READ_SIZE))
 	}
 	if ud.Backlog == 0 {
 		ud.Backlog = 100

--- a/receiver/udp.go
+++ b/receiver/udp.go
@@ -27,18 +27,24 @@ import (
 	"net"
 	"runtime"
 
+	"errors"
 	"github.com/telenornms/skogul"
+)
+
+const (
+	UDP_MAX_READ_SIZE = 65535
 )
 
 var udpLog = skogul.Logger("receiver", "udp")
 
 // UDP contains the configuration for the receiver
 type UDP struct {
-	Address string            `doc:"Address and port to listen to." example:"[::1]:3306"`
-	Handler skogul.HandlerRef `doc:"Handler used to parse, transform and send data."`
-	Backlog int               `doc:"Number of queued messages that are not delievered before the receiver starts blocking. Defaults to 100. Even when this is full, the kernel will still buffer data on top of this value. Higher values give smoother performance, but slightly more memory usage. Actual memory usage is a factor of average message size * backlog-fill."`
-	Threads int               `doc:"Number of worker go routines to use, which loosely translates to parallell execution. Defaults to number of CPU threads, with a minimum of 20. There is no correct number, but the value depends on how fast your senders are."`
-	ch      chan []byte       // Used to pass messages from the accept/read-loop to the worker pool/threads.
+	Address    string            `doc:"Address and port to listen to." example:"[::1]:3306"`
+	Handler    skogul.HandlerRef `doc:"Handler used to parse, transform and send data."`
+	Backlog    int               `doc:"Number of queued messages that are not delivered before the receiver starts blocking. Defaults to 100. Even when this is full, the kernel will still buffer data on top of this value. Higher values give smoother performance, but slightly more memory usage. Actual memory usage is a factor of average message size * backlog-fill."`
+	Threads    int               `doc:"Number of worker go routines to use, which loosely translates to parallel execution. Defaults to number of CPU threads, with a minimum of 20. There is no correct number, but the value depends on how fast your senders are."`
+	ch         chan []byte       // Used to pass messages from the accept/read-loop to the worker pool/threads.
+	PacketSize int               `doc:"UDP Packet size note: max. UDP read size is 65535"`
 }
 
 // process is the worker-thread responsible for handling individual
@@ -56,6 +62,9 @@ func (ud *UDP) process() {
 // listening for incoming UDP messages on the configured address. Start
 // never returns.
 func (ud *UDP) Start() error {
+	if ud.PacketSize < 0 || ud.PacketSize > UDP_MAX_READ_SIZE {
+		return errors.New("invalid udp packet size, maximum udp read size is between 0 and " + string(UDP_MAX_READ_SIZE))
+	}
 	if ud.Backlog == 0 {
 		ud.Backlog = 100
 	}
@@ -82,7 +91,7 @@ func (ud *UDP) Start() error {
 		return err
 	}
 	for {
-		bytes := make([]byte, 9000)
+		bytes := make([]byte, ud.PacketSize)
 		n, err := ln.Read(bytes)
 		if err != nil || n == 0 {
 			udpLog.WithError(err).WithField("bytes", n).Error("Unable to read UDP message")

--- a/receiver/udp_test.go
+++ b/receiver/udp_test.go
@@ -84,29 +84,25 @@ func init() {
 		"udp1": {
 			"type": "udp",
 			"address": "localhost:1939",
-			"handler": "protobuf",
-			"packetsize": 9000
+			"handler": "protobuf"
 		},
 		"udp2": {
 			"type": "udp",
 			"address": "localhost:1959",
 			"handler": "json-sleep",
-			"Threads": 1,
-			"packetsize": 9000
+			"Threads": 1
 		},
 		"udp3": {
 			"type": "udp",
 			"address": "localhost:1969",
 			"handler": "json-sleep",
-			"Threads": 10,
-			"packetsize": 9000
+			"Threads": 10
 		},
 		"udp4": {
 			"type": "udp",
 			"address": "localhost:1979",
 			"handler": "json-sleep",
-			"Threads": 100,
-			"packetsize": 9000
+			"Threads": 100
 		}
 	},
 	"handlers": {

--- a/receiver/udp_test.go
+++ b/receiver/udp_test.go
@@ -84,25 +84,29 @@ func init() {
 		"udp1": {
 			"type": "udp",
 			"address": "localhost:1939",
-			"handler": "protobuf"
+			"handler": "protobuf",
+			"packetsize": 9000
 		},
 		"udp2": {
 			"type": "udp",
 			"address": "localhost:1959",
 			"handler": "json-sleep",
-			"Threads": 1
+			"Threads": 1,
+			"packetsize": 9000
 		},
 		"udp3": {
 			"type": "udp",
 			"address": "localhost:1969",
 			"handler": "json-sleep",
-			"Threads": 10
+			"Threads": 10,
+			"packetsize": 9000
 		},
 		"udp4": {
 			"type": "udp",
 			"address": "localhost:1979",
 			"handler": "json-sleep",
-			"Threads": 100
+			"Threads": 100,
+			"packetsize": 9000
 		}
 	},
 	"handlers": {


### PR DESCRIPTION
making udp packet size. configurable with taking care the UDP_MAX_READ_SIZE which is "65535" and updating the test files 