### PR TITLE
fix: Keep escape character for parsed escaped character sequences

### DIFF
--- a/parser/influxdb.go
+++ b/parser/influxdb.go
@@ -301,12 +301,9 @@ func influxLineParser(data []byte, sectionBreak rune, removeEscapedCharsFromResu
 
 		if escape {
 			escape = false
-			if c == 'x' || c == '0' || c == 'u' {
+			if c != 'x' && c != 'X' && c != '0' && c != 'u' && c != 'U' {
 				// \x is hex, so let's keep the \ and the x so that a consumer can
-				// parse the value themselves.
-			} else {
-				// otherwise, we consider the 'removeEscapedChars' boolean
-				// to decide whether to keep the \ or not.
+				// parse the value themselves. Let's also do the same for decimals (\0) and unicode (\u).
 				if removeEscapedCharsFromResult {
 					escapeChars = append([]int{start - previousWidth}, escapeChars...)
 					escapeCharsWidth = append([]int{previousWidth}, escapeCharsWidth...)

--- a/parser/testdata/influxdb_systemd_units.txt
+++ b/parser/testdata/influxdb_systemd_units.txt
@@ -1,0 +1,17 @@
+systemd_units,active=active,host=localhost,load=loaded,name=containerd.service,sub=running active_code=0i,load_code=0i,sub_code=0i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=crond.service,sub=running active_code=0i,load_code=0i,sub_code=0i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=docker.service,sub=running active_code=0i,load_code=0i,sub_code=0i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=skogul.service,sub=running active_code=0i,load_code=0i,sub_code=0i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=sshd.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=inactive,host=localhost,load=not-found,name=syslog.service,sub=dead active_code=2i,load_code=2i,sub_code=1i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck-root.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-disk-by\x2duuid-8274064c\x2daac0\x2d4346\x2da4d2\x2dc7f785ce59e1.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2dadm.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=inactive,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2ddocker.service,sub=dead active_code=2i,load_code=0i,sub_code=1i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2dhome.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2dlocal.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2dlog.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2dtmp.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-journald.service,sub=running active_code=0i,load_code=0i,sub_code=0i 1619444733000000000
+systemd_units,active=active,host=localhost,load=loaded,name=systemd-logind.service,sub=running active_code=0i,load_code=0i,sub_code=0i 1619444733000000000
+systemd_units,active=inactive,host=localhost,load=loaded,name=systemd-reboot.service,sub=dead active_code=2i,load_code=0i,sub_code=1i 1619444733000000000


### PR DESCRIPTION
e.g. \x2d, or other sequences starting with \x, \u or \0.

Rationale:

Lines such as this one
```
systemd_units,active=active,host=localhost,load=loaded,name=systemd-fsck@dev-mapper-vg00\x2dtmp.service,sub=exited active_code=0i,load_code=0i,sub_code=4i 1619444733000000000
```
contains a character escape sequence for a hex value (`\x2d` = `-`). `\` is treated as an escape character, and would be removed for tag values. Now we keep that character if it is followed by either of the following chars: `x`, `u`, `0`.