### PR TITLE
feat: Support for InfluxDB v2 in influx sender

### DIFF
--- a/common.go
+++ b/common.go
@@ -26,9 +26,10 @@ package skogul
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"runtime"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 /*
@@ -303,4 +304,22 @@ func ExtractNestedObject(object map[string]interface{}, keys []string) (map[stri
 	}
 
 	return ExtractNestedObject(next, keys[1:])
+}
+
+// Secret is a common type that wraps a string where the contents of the string
+// can be sensitive, such as a credential. The String() func will output `***` to prevent accidental exposure,
+// but the raw contents can be `Expose()`d.
+type Secret string
+
+func (s Secret) String() string {
+	return "<redacted>"
+}
+
+func (s Secret) Expose() string {
+	r := ""
+	for _, c := range s {
+		r = fmt.Sprintf("%s%c", r, c)
+	}
+
+	return r
 }

--- a/common.go
+++ b/common.go
@@ -311,10 +311,14 @@ func ExtractNestedObject(object map[string]interface{}, keys []string) (map[stri
 // but the raw contents can be `Expose()`d.
 type Secret string
 
+// String replaces the underlying data with the string "<redacted>"
+// so that it is not accidentally revealed in logs or other debug related outputs.
 func (s Secret) String() string {
 	return "<redacted>"
 }
 
+// Expose must be called when the underlying secret is to be revealed,
+// such as to the service that requires the data.
 func (s Secret) Expose() string {
 	r := ""
 	for _, c := range s {

--- a/common_test.go
+++ b/common_test.go
@@ -239,3 +239,16 @@ func TestParseInvalidContainerAndTransformItValid(t *testing.T) {
 		return
 	}
 }
+
+func TestSecretIsRedacted(t *testing.T) {
+	secret := skogul.Secret("hunter2")
+	if secret.String() != "<redacted>" {
+		t.Errorf("Expected secret to be redacted, but got %s", secret.String())
+	}
+}
+func TestSecretIsExposed(t *testing.T) {
+	secret := skogul.Secret("hunter2")
+	if secret.Expose() != "hunter2" {
+		t.Errorf("Expected secret to be 'hunter2', but got %s", secret.Expose())
+	}
+}

--- a/docs/examples/tester_to_influxdb.json
+++ b/docs/examples/tester_to_influxdb.json
@@ -1,0 +1,27 @@
+{
+  "receivers": {
+    "test": {
+      "type": "test",
+      "handler": "json",
+      "metrics": 100,
+      "values": 100,
+      "threads": 30
+    }
+  },
+  "handlers": {
+    "json": {
+      "parser": "json",
+      "transformers": [],
+      "sender": "influxdbv2"
+    }
+  },
+  "senders": {
+	  "debug": {
+	  "type": "debug"},
+    "influxdbv2": {
+      "type": "influx",
+      "url": "http://localhost:55000/write?db=skogul",
+      "measurement": "skogul"
+    }
+  }
+}

--- a/sender/influxdb.go
+++ b/sender/influxdb.go
@@ -115,6 +115,12 @@ func (idb *InfluxDB) Send(c *skogul.Container) error {
 			// XXX: Should rneport.
 			continue
 		}
+		// Set time from template if we don't have a time and the template does.
+		if m.Time == nil {
+			if c.Template != nil && c.Template.Time != nil {
+				m.Time = c.Template.Time
+			}
+		}
 		if idb.MeasurementFromMetadata != "" {
 			measure, ok := m.Metadata[idb.MeasurementFromMetadata].(string)
 			if ok {


### PR DESCRIPTION
* Adds the configuration field "Token" to the InfluxDB sender, to support v2 of the write API.
* Changes how we create and do requests to support this change.
* Adds a "Secret"-type that can be used for configuration secrets to prevent them from being leaked.

Resolves #175.