### PR TITLE
feat: Add a custom type for Secrets

### DIFF
--- a/common.go
+++ b/common.go
@@ -26,9 +26,10 @@ package skogul
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"runtime"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 /*
@@ -303,4 +304,21 @@ func ExtractNestedObject(object map[string]interface{}, keys []string) (map[stri
 	}
 
 	return ExtractNestedObject(next, keys[1:])
+}
+
+// Secret is a common type that wraps a string where the contents of the string
+// can be sensitive, such as a credential. The String() func will output `***` to prevent accidental exposure,
+// but the raw contents can be `Expose()`d.
+type Secret string
+
+// String replaces the underlying data with the string "<redacted>"
+// so that it is not accidentally revealed in logs or other debug related outputs.
+func (s Secret) String() string {
+	return "<redacted>"
+}
+
+// Expose must be called when the underlying secret is to be revealed,
+// such as to the service that requires the data.
+func (s Secret) Expose() string {
+	return string(s)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -239,3 +239,16 @@ func TestParseInvalidContainerAndTransformItValid(t *testing.T) {
 		return
 	}
 }
+
+func TestSecretIsRedacted(t *testing.T) {
+	secret := skogul.Secret("hunter2")
+	if secret.String() != "<redacted>" {
+		t.Errorf("Expected secret to be redacted, but got %s", secret.String())
+	}
+}
+func TestSecretIsExposed(t *testing.T) {
+	secret := skogul.Secret("hunter2")
+	if secret.Expose() != "hunter2" {
+		t.Errorf("Expected secret to be 'hunter2', but got %s", secret.Expose())
+	}
+}


### PR DESCRIPTION
I've purposefully not converted existing "secrets" to this new syntax, but I can do that as part of this change as well.