### PR TITLE
fix(tester): Set time on metric in tester

### DIFF
--- a/docs/examples/tester_to_influxdb.json
+++ b/docs/examples/tester_to_influxdb.json
@@ -1,0 +1,25 @@
+{
+  "receivers": {
+    "test": {
+      "type": "test",
+      "handler": "json",
+      "metrics": 100,
+      "values": 100,
+      "threads": 30
+    }
+  },
+  "handlers": {
+    "json": {
+      "parser": "json",
+      "transformers": [],
+      "sender": "influxdb"
+    }
+  },
+  "senders": {
+    "influxdb": {
+      "type": "influx",
+      "url": "http://localhost:8086/write?db=skogul",
+      "measurement": "skogul"
+    }
+  }
+}

--- a/receiver/tester.go
+++ b/receiver/tester.go
@@ -45,11 +45,10 @@ type Tester struct {
 
 func (tst *Tester) generate(t time.Time) skogul.Container {
 	c := skogul.Container{}
-	c.Template = &skogul.Metric{}
-	c.Template.Time = &t
 	c.Metrics = make([]*skogul.Metric, tst.Metrics)
 	for i := int64(0); i < tst.Metrics; i++ {
 		m := skogul.Metric{}
+		m.Time = &t
 		m.Metadata = map[string]interface{}{}
 		m.Metadata["key1"] = i
 		m.Data = map[string]interface{}{}


### PR DESCRIPTION
Skogul would panic with a simple tester receiver sending to influxdb with the attached configuration example.

```
INFO[0000] Starting skogul                               category=cmd cmd=main
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14ca6a0]

goroutine 43 [running]:
github.com/telenornms/skogul/sender.(*InfluxDB).Send(0xc000131560, 0xc0001b85a0)
        /Users/sklirg/Documents/git/github/telenornms/skogul/sender/influxdb.go:179 +0x3e0
github.com/telenornms/skogul.(*Handler).Send(0xc0001d4d48, 0x64)
        /Users/sklirg/Documents/git/github/telenornms/skogul/common.go:218 +0x4b
github.com/telenornms/skogul.(*Handler).TransformAndSend(0xc0001d6640, 0xc0522d0780ab99b0)
        /Users/sklirg/Documents/git/github/telenornms/skogul/common.go:243 +0x3f
github.com/telenornms/skogul/receiver.(*Tester).run(0xc0001d6640)
        /Users/sklirg/Documents/git/github/telenornms/skogul/receiver/tester.go:90 +0xb9
created by github.com/telenornms/skogul/receiver.(*Tester).Start
        /Users/sklirg/Documents/git/github/telenornms/skogul/receiver/tester.go:80 +0x3de
exit status 2
```

The attached fix resolves this problem by setting the "time" field on all skogul metrics.