### PR TITLE
Draft: Use JSON Pointers for specifying paths in JSON documents

### DIFF
--- a/common.go
+++ b/common.go
@@ -291,21 +291,6 @@ func Assert(x bool, v ...interface{}) {
 	}
 }
 
-// ExtractNestedObject extracts an object from a nested object structure. All intermediate objects has to map[string]interface{}
-func ExtractNestedObject(object map[string]interface{}, keys []string) (map[string]interface{}, error) {
-	if len(keys) == 1 {
-		return object, nil
-	}
-
-	next, ok := object[keys[0]].(map[string]interface{})
-
-	if !ok {
-		return nil, Error{Reason: "Failed to cast nested object to map[string]interface{}"}
-	}
-
-	return ExtractNestedObject(next, keys[1:])
-}
-
 // Secret is a common type that wraps a string where the contents of the string
 // can be sensitive, such as a credential. The String() func will output `***` to prevent accidental exposure,
 // but the raw contents can be `Expose()`d.

--- a/docs/examples/udp-protobuf-transform.json
+++ b/docs/examples/udp-protobuf-transform.json
@@ -17,7 +17,7 @@
   "transformers": {
     "split": {
       "type": "split",
-      "field": ["interfaceExp_stats"]
+      "field": "/interfaceExp_stats"
     },
     "extract": {
       "type": "metadata",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/telenornms/skogul
 go 1.12
 
 require (
+	github.com/dolmen-go/jsonptr v0.0.0-20200427210345-20e1608f9d85 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dolmen-go/jsonptr v0.0.0-20200427210345-20e1608f9d85 h1:UehF9pCOF1JiOLmeZavootTCuimvkW7N1wggjyW4S90=
+github.com/dolmen-go/jsonptr v0.0.0-20200427210345-20e1608f9d85/go.mod h1:+6ZQtcQuiOH4ATMF+4885rhnE3FaM++MhE7m7vM302s=
 github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=

--- a/transformer/metadata.go
+++ b/transformer/metadata.go
@@ -100,19 +100,19 @@ func flattenStructure(nestedPath jsonptr.Pointer, separator string, metric *skog
 	}
 
 	ptr := nestedPath.Copy()
-	obj, err := jsonptr.Get(metric.Data, ptr.String())
+	val, err := jsonptr.Get(metric.Data, ptr.String())
 
 	if err == nil {
-		nestedObj, ok := obj.(map[string]interface{})
+		nestedObj, ok := val.(map[string]interface{})
 
 		if !ok {
 
-			nestedObjArray, ok := obj.([]interface{})
+			nestedObjArray, ok := val.([]interface{})
 			if !ok {
 				// it is not an object and not an array,
 				// we'll assume the type is supposed to be what it is now.
 
-				metric.Data[fmt.Sprintf("%s%s%s", nestedObjectPath, separator, ptr.Pop())] = obj
+				metric.Data[fmt.Sprintf("%s%s%s", nestedObjectPath, separator, ptr.Pop())] = val
 
 				return nil
 			}

--- a/transformer/metadata.go
+++ b/transformer/metadata.go
@@ -27,6 +27,7 @@ package transformer
 import (
 	"fmt"
 
+	"github.com/dolmen-go/jsonptr"
 	"github.com/telenornms/skogul"
 )
 
@@ -83,7 +84,7 @@ func (meta *Metadata) Transform(c *skogul.Container) error {
 }
 
 // flattenStructure copies a nested object/array to the root level
-func flattenStructure(nestedPath []string, separator string, metric *skogul.Metric) error {
+func flattenStructure(nestedPath jsonptr.Pointer, separator string, metric *skogul.Metric) error {
 	nestedObjectPath := nestedPath[0]
 
 	// Create a nested path unless configuration says not to
@@ -98,14 +99,14 @@ func flattenStructure(nestedPath []string, separator string, metric *skogul.Metr
 		nestedObjectPath = ""
 	}
 
-	obj, err := skogul.ExtractNestedObject(metric.Data, nestedPath)
+	obj, err := jsonptr.Get(metric.Data, nestedPath.String())
 
 	if err == nil {
-		nestedObj, ok := obj[nestedPath[len(nestedPath)-1]].(map[string]interface{})
+		nestedObj, ok := obj.(map[string]interface{})
 
 		if !ok {
 
-			nestedObjArray, ok := obj[nestedPath[len(nestedPath)-1]].([]interface{})
+			nestedObjArray, ok := obj.([]interface{})
 			if !ok {
 				return skogul.Error{Reason: "Failed cast"}
 			}
@@ -145,7 +146,7 @@ func flattenStructure(nestedPath []string, separator string, metric *skogul.Metr
 type Data struct {
 	Set              map[string]interface{} `doc:"Set data fields to specific values."`
 	Require          []string               `doc:"Require the pressence of these data fields."`
-	Flatten          [][]string             `doc:"Flatten nested structures down to the root level"`
+	Flatten          []jsonptr.Pointer      `doc:"Flatten nested structures down to the root level"`
 	FlattenSeparator string                 `doc:"Custom separator to use for flattening. Use 'drop' to drop intermediate keys. This will overwrite existing keys with the same name."`
 	Remove           []string               `doc:"Remove these data fields."`
 	Ban              []string               `doc:"Fail if any of these data fields are present"`

--- a/transformer/metadata.go
+++ b/transformer/metadata.go
@@ -99,7 +99,8 @@ func flattenStructure(nestedPath jsonptr.Pointer, separator string, metric *skog
 		nestedObjectPath = ""
 	}
 
-	obj, err := jsonptr.Get(metric.Data, nestedPath.String())
+	ptr := nestedPath.Copy()
+	obj, err := jsonptr.Get(metric.Data, ptr.String())
 
 	if err == nil {
 		nestedObj, ok := obj.(map[string]interface{})
@@ -108,7 +109,12 @@ func flattenStructure(nestedPath jsonptr.Pointer, separator string, metric *skog
 
 			nestedObjArray, ok := obj.([]interface{})
 			if !ok {
-				return skogul.Error{Reason: "Failed cast"}
+				// it is not an object and not an array,
+				// we'll assume the type is supposed to be what it is now.
+
+				metric.Data[fmt.Sprintf("%s%s%s", nestedObjectPath, separator, ptr.Pop())] = obj
+
+				return nil
 			}
 
 			nestedObj = make(map[string]interface{})

--- a/transformer/metadata_test.go
+++ b/transformer/metadata_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/dolmen-go/jsonptr"
 	"github.com/telenornms/skogul"
 	"github.com/telenornms/skogul/config"
 	"github.com/telenornms/skogul/transformer"
@@ -176,6 +177,7 @@ func TestExtract(t *testing.T) {
 
 func TestFlattenMap(t *testing.T) {
 	path := "nestedData"
+	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))
 	extracted_value_key := "key"
 	extracted_value := "value"
 
@@ -189,7 +191,7 @@ func TestFlattenMap(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	data := transformer.Data{
-		Flatten: [][]string{{path}},
+		Flatten: []jsonptr.Pointer{pointer},
 	}
 
 	err := data.Transform(&c)
@@ -202,7 +204,8 @@ func TestFlattenMap(t *testing.T) {
 
 	// Expect data to be accessible at its new location
 	if c.Metrics[0].Data[new_path] != extracted_value {
-		t.Errorf(`Expected "%s" but got "%s"`, extracted_value, c.Metrics[0].Data[new_path])
+		t.Errorf(`Expected "%s" but got "%s" for key "%s"`, extracted_value, c.Metrics[0].Data[new_path], new_path)
+		fmt.Println(c.Metrics[0].Data)
 	}
 
 	// Expect data to still be accessible at its original location
@@ -218,6 +221,7 @@ func TestFlattenMap(t *testing.T) {
 
 func TestFlattenMapDefaultSeparator(t *testing.T) {
 	path := "nestedData"
+	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))
 	extracted_value_key := "key"
 	extracted_value := "value"
 
@@ -231,7 +235,7 @@ func TestFlattenMapDefaultSeparator(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	data := transformer.Data{
-		Flatten:          [][]string{{path}},
+		Flatten:          []jsonptr.Pointer{pointer},
 		FlattenSeparator: "",
 	}
 
@@ -261,6 +265,7 @@ func TestFlattenMapDefaultSeparator(t *testing.T) {
 
 func TestFlattenMapCustomSeparator(t *testing.T) {
 	path := "nestedData"
+	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))
 	extracted_value_key := "key"
 	extracted_value := "value"
 	separator := "!SEP!"
@@ -275,7 +280,7 @@ func TestFlattenMapCustomSeparator(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	data := transformer.Data{
-		Flatten:          [][]string{{path}},
+		Flatten:          []jsonptr.Pointer{pointer},
 		FlattenSeparator: separator,
 	}
 
@@ -305,6 +310,7 @@ func TestFlattenMapCustomSeparator(t *testing.T) {
 
 func TestFlattenMapDropSeparator(t *testing.T) {
 	path := "nestedData"
+	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))
 	extracted_value_key := "key"
 	extracted_value := "value"
 	separator := "drop"
@@ -319,7 +325,7 @@ func TestFlattenMapDropSeparator(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	data := transformer.Data{
-		Flatten:          [][]string{{path}},
+		Flatten:          []jsonptr.Pointer{pointer},
 		FlattenSeparator: separator,
 	}
 
@@ -349,6 +355,7 @@ func TestFlattenMapDropSeparator(t *testing.T) {
 
 func TestFlattenArray(t *testing.T) {
 	path := "nestedData"
+	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))
 	extracted_value_key := "0"
 	extracted_value := "value"
 
@@ -362,7 +369,7 @@ func TestFlattenArray(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	data := transformer.Data{
-		Flatten: [][]string{{path}},
+		Flatten: []jsonptr.Pointer{pointer},
 	}
 
 	err := data.Transform(&c)
@@ -380,6 +387,7 @@ func TestFlattenArray(t *testing.T) {
 
 func TestFlattenArrayOfMaps(t *testing.T) {
 	path := "nestedData"
+	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))
 	extracted_value_key := "0"
 	extracted_value_key_2 := "key"
 	extracted_value := "value"
@@ -394,7 +402,7 @@ func TestFlattenArrayOfMaps(t *testing.T) {
 	c.Metrics = []*skogul.Metric{&metric}
 
 	data := transformer.Data{
-		Flatten: [][]string{{path}},
+		Flatten: []jsonptr.Pointer{pointer},
 	}
 
 	err := data.Transform(&c)

--- a/transformer/metadata_test.go
+++ b/transformer/metadata_test.go
@@ -219,6 +219,39 @@ func TestFlattenMap(t *testing.T) {
 	}
 }
 
+func TestFlattenMap2(t *testing.T) {
+	jsonData := []byte(`{
+	"system": {
+		"hostname": "foo",
+		"platform": "bar"
+	}
+}`)
+	var data map[string]interface{}
+	json.Unmarshal(jsonData, &data)
+
+	container := skogul.Container{
+		Metrics: []*skogul.Metric{
+			{
+				Data: data,
+			},
+		},
+	}
+
+	conf := transformer.Data{
+		Flatten:          []jsonptr.Pointer{jsonptr.MustParse("/system/hostname")},
+		FlattenSeparator: "drop",
+	}
+
+	if err := conf.Transform(&container); err != nil {
+		t.Errorf("failed to run flatten transformer: %s", err)
+	}
+
+	rootHostname := container.Metrics[0].Data["hostname"]
+	if rootHostname == nil || rootHostname != "foo" {
+		t.Errorf("expected to find 'foo' for 'hostname' on the root level of the transformed metric.Data, but found '%v'", rootHostname)
+	}
+}
+
 func TestFlattenMapDefaultSeparator(t *testing.T) {
 	path := "nestedData"
 	pointer := jsonptr.MustParse(fmt.Sprintf("/%s", path))

--- a/transformer/split_test.go
+++ b/transformer/split_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/dolmen-go/jsonptr"
 	"github.com/telenornms/skogul"
 	"github.com/telenornms/skogul/transformer"
 )
@@ -78,9 +79,9 @@ func TestSplit(t *testing.T) {
 		return
 	}
 
-	split_path := "data"
+	split_path := "/data"
 	metadata := transformer.Split{
-		Field: []string{split_path},
+		Field: jsonptr.MustParse(split_path),
 	}
 
 	if err := metadata.Transform(&c); err != nil {


### PR DESCRIPTION
Reworks the current "list of strings" implementation of paths in JSON documents into using the JSON Pointer package [dolmen-go/jsonptr](github.com/dolmen-go/jsonptr). Existing test cases have been updated for this change, as this is a breaking change for configuring the affected transformers.

⚠️ This will be a breaking change for the `flatten`, `timestamp` and `metadata.Flatten` transformers.

Also partly resolves #191.
Note: it does not resolve the second part of the issue mentioning "an easy way of renaming [the extracted fields]".