### PR TITLE
fix: Don't crash skogul on parsing negative Infinity values

### DIFF
--- a/parser/protobuf.go
+++ b/parser/protobuf.go
@@ -149,7 +149,7 @@ func createData(telemetry *pb.TelemetryStream) map[string]interface{} {
 
 		jsonMessage, err = json.Marshal(messageOnly)
 		if err != nil {
-			pbLog.WithError(err).Fatal("Failed to marshal to JSON")
+			pbLog.WithError(err).Error("Failed to marshal data to JSON")
 			return nil
 		}
 

--- a/parser/protobuf_test.go
+++ b/parser/protobuf_test.go
@@ -24,9 +24,14 @@
 package parser_test
 
 import (
+	"fmt"
+	"math"
 	"os"
 	"testing"
+	"time"
 
+	proto "github.com/golang/protobuf/proto"
+	junos_protobuf_telemetry "github.com/telenornms/skogul/gen/junos/telemetry"
 	"github.com/telenornms/skogul/parser"
 )
 
@@ -70,5 +75,130 @@ func BenchmarkProtoBufParse(b *testing.B) {
 	x := parser.ProtoBuf{}
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
+	}
+}
+
+func generateJunosTelemetryStream(sensorName string, eps junos_protobuf_telemetry.EnterpriseSensors) junos_protobuf_telemetry.TelemetryStream {
+	systemId := "localhost"
+	now := uint64(time.Now().Unix())
+	componentId := uint32(1)
+	subComponentId := uint32(2)
+
+	return junos_protobuf_telemetry.TelemetryStream{
+		SystemId:       &systemId,
+		Timestamp:      &now,
+		ComponentId:    &componentId,
+		SubComponentId: &subComponentId,
+		SensorName:     &sensorName,
+		Enterprise:     (*junos_protobuf_telemetry.EnterpriseSensors)(&eps),
+		// Should this be used ?  Ietf:       (*junos_protobuf_telemetry.IETFSensors)(&juniperNetworksSensors),
+	}
+}
+
+func generateOpticsDiag(val float64) junos_protobuf_telemetry.TelemetryStream {
+	eps := junos_protobuf_telemetry.EnterpriseSensors{}
+	juniperNetworksSensors := junos_protobuf_telemetry.JuniperNetworksSensors{}
+	if err := proto.SetExtension(&eps, junos_protobuf_telemetry.E_JuniperNetworks, &juniperNetworksSensors); err != nil {
+		fmt.Printf("Failed to set juniperNetworks extension: %v\n", err)
+	}
+
+	ifName := "ge-1/0/1"
+	optics := junos_protobuf_telemetry.Optics{
+		OpticsDiag: []*junos_protobuf_telemetry.OpticsInfos{
+			{
+				IfName: &ifName,
+				OpticsDiagStats: &junos_protobuf_telemetry.OpticsDiagStats{
+					OpticsLaneDiagStats: []*junos_protobuf_telemetry.OpticsDiagLaneStats{
+						{
+							LaneLaserReceiverPowerDbm: &val,
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := proto.SetExtension(&juniperNetworksSensors, junos_protobuf_telemetry.E_JnprOpticsExt, &optics); err != nil {
+		fmt.Printf("Failed to set Optics extension: %v\n", err)
+	}
+	return generateJunosTelemetryStream("foo", eps)
+}
+
+func parseDiagStatsResp(data map[string]interface{}, key string) interface{} {
+	opticsDiag, ok := data["Optics_diag"].([]interface{})
+	if !ok {
+		fmt.Printf("failed to cast")
+	}
+	foo, ok := opticsDiag[0].(map[string]interface{})
+	if !ok {
+		fmt.Printf("failed to cast 2")
+	}
+	opticsDiagStats := foo["optics_diag_stats"].(map[string]interface{})
+
+	opticsLaneDiagStats := opticsDiagStats["optics_lane_diag_stats"].([]interface{})
+
+	bar, ok := opticsLaneDiagStats[0].(map[string]interface{})
+	if !ok {
+		fmt.Printf("failed to cast 3")
+	}
+
+	return bar[key]
+}
+
+func TestParseJunosProtobufTelemetryStreamOptics(t *testing.T) {
+	expected := float64(-40)
+	telemetry := generateOpticsDiag(expected)
+
+	bytes, err := proto.Marshal(&telemetry)
+	if err != nil {
+		t.Errorf("Failed to marshal protobuf message to bytes: %v", err)
+		return
+	}
+	if bytes == nil {
+		t.Error("Bytes marshalling resulted in nil")
+		return
+	}
+
+	protobuf_parser := parser.ProtoBuf{}
+	c, err := protobuf_parser.Parse(bytes)
+	if err != nil {
+		t.Errorf("Failed to parse optics diag lane stats protobuf data, err: %v", err)
+	}
+	if c == nil {
+		t.Error("Protobuf parse returned nil-container")
+	}
+
+	got := parseDiagStatsResp(c.Metrics[0].Data, "lane_laser_receiver_power_dbm")
+	if got != expected {
+		t.Errorf("Expected lane_laser_receiver_power_dbm to be %T(%v), but got %T(%v)", expected, expected, got, got)
+	}
+}
+
+func TestParseJunosProtobufTelemetryStreamOpticsNegativeInf(t *testing.T) {
+	expected := float64(math.Inf(-1))
+	telemetry := generateOpticsDiag(math.Inf(-1))
+
+	bytes, err := proto.Marshal(&telemetry)
+	if err != nil {
+		t.Errorf("Failed to marshal protobuf message to bytes: %v", err)
+		return
+	}
+	if bytes == nil {
+		t.Error("Bytes marshalling resulted in nil")
+		return
+	}
+
+	protobuf_parser := parser.ProtoBuf{}
+	c, err := protobuf_parser.Parse(bytes)
+	if err != nil {
+		t.Errorf("Failed to parse optics diag lane stats protobuf data, err: %v", err)
+		return
+	}
+	if c == nil {
+		t.Error("Protobuf parse returned nil-container")
+	}
+
+	got := parseDiagStatsResp(c.Metrics[0].Data, "lane_laser_receiver_power_dbm")
+	if got != expected {
+		t.Errorf("Expected lane_laser_receiver_power_dbm to be %T(%v), but got %T(%v)", expected, expected, got, got)
 	}
 }

--- a/parser/protobuf_test.go
+++ b/parser/protobuf_test.go
@@ -175,7 +175,7 @@ func TestParseJunosProtobufTelemetryStreamOptics(t *testing.T) {
 
 func TestParseJunosProtobufTelemetryStreamOpticsNegativeInf(t *testing.T) {
 	expected := float64(math.Inf(-1))
-	telemetry := generateOpticsDiag(math.Inf(-1))
+	telemetry := generateOpticsDiag(expected)
 
 	bytes, err := proto.Marshal(&telemetry)
 	if err != nil {
@@ -188,17 +188,8 @@ func TestParseJunosProtobufTelemetryStreamOpticsNegativeInf(t *testing.T) {
 	}
 
 	protobuf_parser := parser.ProtoBuf{}
-	c, err := protobuf_parser.Parse(bytes)
-	if err != nil {
-		t.Errorf("Failed to parse optics diag lane stats protobuf data, err: %v", err)
+	if _, err := protobuf_parser.Parse(bytes); err == nil {
+		t.Errorf("Expected parsing -Inf values to return an error, ref issue #194.")
 		return
-	}
-	if c == nil {
-		t.Error("Protobuf parse returned nil-container")
-	}
-
-	got := parseDiagStatsResp(c.Metrics[0].Data, "lane_laser_receiver_power_dbm")
-	if got != expected {
-		t.Errorf("Expected lane_laser_receiver_power_dbm to be %T(%v), but got %T(%v)", expected, expected, got, got)
 	}
 }


### PR DESCRIPTION
Resolves #194.

Note: The parser will still error and produce no container, so the data is effectively lost. This problem is tracked in #195.