### PR TITLE
Add DictSplit transformer and expand Split somewhat

### DIFF
--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -60,7 +60,13 @@ func init() {
 		Name:    "split",
 		Aliases: []string{},
 		Alloc:   func() interface{} { return &Split{} },
-		Help:    "Splits a metric into multiple metrics based on a field.",
+		Help:    "Split an array inside a metric into multiple metrics, one for each array element.",
+	})
+	Auto.Add(skogul.Module{
+		Name:    "dictsplit",
+		Aliases: []string{},
+		Alloc:   func() interface{} { return &DictSplit{} },
+		Help:    "Split a dictionary/hash inside a metric into multiple metrics, one for each dictinoary/hash element.",
 	})
 	Auto.Add(skogul.Module{
 		Name:    "replace",

--- a/transformer/split_test.go
+++ b/transformer/split_test.go
@@ -80,7 +80,8 @@ func TestSplit(t *testing.T) {
 
 	split_path := "data"
 	metadata := transformer.Split{
-		Field: []string{split_path},
+		Field:        []string{split_path},
+		MetadataName: "arrayidx",
 	}
 
 	if err := metadata.Transform(&c); err != nil {
@@ -97,9 +98,15 @@ func TestSplit(t *testing.T) {
 	if c.Metrics[0].Data["data"] != "yes" {
 		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "yes", c.Metrics[0].Data["data"])
 	}
+	if c.Metrics[0].Metadata["arrayidx"] != 0 {
+		t.Errorf(`Expected Metrics Metadata key arrayidx to contain key arrayidx of val '%d' but got '%v'`, 0, c.Metrics[0].Metadata["arrayidx"])
+	}
 
 	if c.Metrics[1].Data["data"] != "yes also" {
 		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "yes also", c.Metrics[1].Data["data"])
+	}
+	if c.Metrics[1].Metadata["arrayidx"] != 1 {
+		t.Errorf(`Expected Metrics Metadata key arrayidx to contain key arrayidx of val '%d' but got '%v'`, 1, c.Metrics[1].Metadata["arrayidx"])
 	}
 	if c.Metrics[2].Data["data"] != "bad" {
 		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "bad", c.Metrics[2].Data["data"])
@@ -107,7 +114,72 @@ func TestSplit(t *testing.T) {
 	if c.Metrics[3].Data["data"] != "2yes" {
 		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "2yes", c.Metrics[3].Data["data"])
 	}
+	if c.Metrics[3].Metadata["arrayidx"] != 0 {
+		t.Errorf(`Expected Metrics Metadata key arrayidx to contain key arrayidx of val '%d' but got '%v'`, 0, c.Metrics[3].Metadata["arrayidx"])
+	}
 	if c.Metrics[4].Data["data"] != "2yes also" {
 		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "2yes also", c.Metrics[4].Data["data"])
 	}
+	if c.Metrics[4].Metadata["arrayidx"] != 1 {
+		t.Errorf(`Expected Metrics Metadata key arrayidx to contain key arrayidx of val '%d' but got '%v'`, 1, c.Metrics[4].Metadata["arrayidx"])
+	}
+}
+func TestSplit_dict(t *testing.T) {
+	var c skogul.Container
+	testData := `
+	{
+		"metrics": [
+		{
+			"data": {
+				"dict": {
+					"fookey": {
+						"name": "foo",
+						"key": "value1"
+					},
+					"barkey": {
+						"name": "bar",
+						"key": "value2"
+					}
+				}
+			}
+
+		}
+		]
+	}
+	`
+	if err := json.Unmarshal([]byte(testData), &c); err != nil {
+		t.Error(err)
+		return
+	}
+
+	split_path := "dict"
+	metadata := transformer.DictSplit{
+		Field:        []string{split_path},
+		MetadataName: "keyname",
+	}
+
+	if err := metadata.Transform(&c); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if len(c.Metrics) != 2 {
+		t.Errorf(`Expected c.Metrics to be of len %d but got %d`, 5, len(c.Metrics))
+		return
+	}
+
+	// Verify that the data is not the same in the two objects as it might differ
+	if c.Metrics[0].Data["name"] != "foo" {
+		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "foo", c.Metrics[0].Data["name"])
+	}
+	if c.Metrics[0].Metadata["keyname"] != "fookey" {
+		t.Errorf(`Expected Metrics Metadata key 'keyname' to have value of 'fookey', but got '%s'`, c.Metrics[0].Metadata["keyname"])
+	}
+	if c.Metrics[1].Data["name"] != "bar" {
+		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "bar", c.Metrics[0].Data["name"])
+	}
+	if c.Metrics[1].Metadata["keyname"] != "barkey" {
+		t.Errorf(`Expected Metrics Metadata key 'keyname' to have value of 'barkey', but got '%s'`, c.Metrics[0].Metadata["keyname"])
+	}
+
 }

--- a/transformer/split_test.go
+++ b/transformer/split_test.go
@@ -169,17 +169,29 @@ func TestSplit_dict(t *testing.T) {
 	}
 
 	// Verify that the data is not the same in the two objects as it might differ
-	if c.Metrics[0].Data["name"] != "foo" {
-		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "foo", c.Metrics[0].Data["name"])
+	test1 := 0
+	test2 := 1
+	if c.Metrics[0].Data["name"] == "foo" && c.Metrics[1].Data["name"] == "bar" {
+		test1 = 0
+		test2 = 1
+	} else if c.Metrics[1].Data["name"] == "foo" && c.Metrics[0].Data["name"] == "bar" {
+		test1 = 1
+		test2 = 0
+	} else {
+		t.Errorf(`Expected Metrics not present for dict split?`)
 	}
-	if c.Metrics[0].Metadata["keyname"] != "fookey" {
-		t.Errorf(`Expected Metrics Metadata key 'keyname' to have value of 'fookey', but got '%s'`, c.Metrics[0].Metadata["keyname"])
+
+	if c.Metrics[test1].Data["name"] != "foo" {
+		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "foo", c.Metrics[test1].Data["name"])
 	}
-	if c.Metrics[1].Data["name"] != "bar" {
-		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "bar", c.Metrics[0].Data["name"])
+	if c.Metrics[test1].Metadata["keyname"] != "fookey" {
+		t.Errorf(`Expected Metrics Metadata key 'keyname' to have value of 'fookey', but got '%s'`, c.Metrics[test1].Metadata["keyname"])
 	}
-	if c.Metrics[1].Metadata["keyname"] != "barkey" {
-		t.Errorf(`Expected Metrics Metadata key 'keyname' to have value of 'barkey', but got '%s'`, c.Metrics[0].Metadata["keyname"])
+	if c.Metrics[test2].Data["name"] != "bar" {
+		t.Errorf(`Expected Metrics Data to contain key of val '%s' but got '%s'`, "bar", c.Metrics[test2].Data["name"])
+	}
+	if c.Metrics[test2].Metadata["keyname"] != "barkey" {
+		t.Errorf(`Expected Metrics Metadata key 'keyname' to have value of 'barkey', but got '%s'`, c.Metrics[test2].Metadata["keyname"])
 	}
 
 }

--- a/transformer/split_test.go
+++ b/transformer/split_test.go
@@ -169,6 +169,11 @@ func TestSplit_dict(t *testing.T) {
 	}
 
 	// Verify that the data is not the same in the two objects as it might differ
+	// Since dictionaries/hashes are unsorted, there's no guarantee
+	// that c.Metrics[0] is the first data listed in the data set
+	// above, though it usually has been for now. Thus we try to detect
+	// which test is which. This sort of makes us verify parts of the
+	// test twice, though.
 	test1 := 0
 	test2 := 1
 	if c.Metrics[0].Data["name"] == "foo" && c.Metrics[1].Data["name"] == "bar" {


### PR DESCRIPTION
The code is depressingly duplicated, save for the casting, but I
honestly don't know how to remedy that.

This commit does TWO things:

1. It introduces a DictSplit transformer, which is the
   map[string]interface{} equivalent to the []interface{} version which
   is Split.
2. It adds MetadataName to both of them, which allows saving the key
   which is split on to metadata. For arrays, this will be the array
   index, starting with 0. For dict, it's the key of the dictionary,
   which is clearly useful.

(Test cases are fixed in second commit)