### PR TITLE
fix: Allow syslog structured data without hostname

### DIFF
--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -165,10 +165,10 @@ func structuredDataParser(bytes []byte, removeEscapedCharsFromResult, stopOnNewM
 	escape := false
 	escapeChars := make([]int, 0)
 	escapeCharsWidth := make([]int, 0)
-	start := 0
-	for width := 0; start < len(bytes); start += width {
+	tokens = 0
+	for width := 0; tokens < len(bytes); tokens += width {
 		var c rune
-		c, width = utf8.DecodeRune(bytes[start:])
+		c, width = utf8.DecodeRune(bytes[tokens:])
 
 		if escape {
 			escape = false
@@ -202,7 +202,7 @@ func structuredDataParser(bytes []byte, removeEscapedCharsFromResult, stopOnNewM
 		if c == '\\' {
 			escape = true
 			if removeEscapedCharsFromResult {
-				escapeChars = append([]int{start}, escapeChars...)
+				escapeChars = append([]int{tokens}, escapeChars...)
 				escapeCharsWidth = append([]int{width}, escapeCharsWidth...)
 			}
 			continue
@@ -217,13 +217,12 @@ func structuredDataParser(bytes []byte, removeEscapedCharsFromResult, stopOnNewM
 		}
 	}
 
-	// Prepare the return values
-	data = bytes[:start]
-	tokens = len(data)
+	// Prepare the return value
+	data = bytes[:tokens]
 
 	for i, escapedChar := range escapeChars {
 		if removeEscapedCharsFromResult {
-			data = []byte(fmt.Sprintf("%s%s", data[0:escapedChar], data[escapedChar+escapeCharsWidth[i]:start]))
+			data = []byte(fmt.Sprintf("%s%s", data[0:escapedChar], data[escapedChar+escapeCharsWidth[i]:tokens]))
 		}
 		tokens += escapeCharsWidth[i]
 	}

--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -37,6 +37,9 @@ var sdLog = skogul.Logger("parser", "structured_data")
 
 // StructuredData supports parsing RFC5424 structured data through the Parse() function
 // Note: This does not parse a full syslog message.
+// In the resulting metrics, there may be a metadata field with the key
+// "SD-ID" which contains the SD-ID from the message if it was present.
+// SD-ID: https://datatracker.ietf.org/doc/html/draft-ietf-syslog-protocol-23#section-6.3.2
 type StructuredData struct{}
 
 // Parse converts RFC5424 Structured Data data into a skogul Container
@@ -82,6 +85,7 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 			tagValue := strings.SplitN(tag, "=", 2)
 
 			if len(tagValue) == 1 && metric.Metadata["sd-id"] == nil {
+				// Set the SD-ID if it exists in the message (https://datatracker.ietf.org/doc/html/draft-ietf-syslog-protocol-23#section-6.3.2)
 				metric.Metadata["sd-id"] = tagValue[0]
 				continue
 			}

--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -235,8 +235,8 @@ func structuredDataParser(data []byte, removeEscapedCharsFromResult, stopOnNewMe
 
 	if stopOnNewMetric {
 		r := data[skipLeadingChars:start]
-		return len(data[:start]) + 1, r
+		return len(data[:start]) + skippedWidth, r
 	}
 
-	return len(data[:start]) + 1, data[skipLeadingChars:start]
+	return len(data[:start]) + skippedWidth, data[skipLeadingChars:start]
 }

--- a/parser/structured_data.go
+++ b/parser/structured_data.go
@@ -70,6 +70,8 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 		kvScanner := bufio.NewScanner(bytes.NewReader(line))
 		kvScanner.Split(splitKeyValuePairs)
 
+		has_hostname := false
+
 		var metric *skogul.Metric
 		for {
 			canContinue := kvScanner.Scan()
@@ -95,7 +97,15 @@ func (sd *StructuredData) parseStructuredData(data []byte) ([]*skogul.Metric, er
 					Data:     make(map[string]interface{}),
 				}
 				metric.Metadata["sd-id"] = tagValue[0]
+				has_hostname = true
 				continue
+			} else if !has_hostname {
+				metric = &skogul.Metric{
+					Time:     &timestamp,
+					Metadata: make(map[string]interface{}),
+					Data:     make(map[string]interface{}),
+				}
+				has_hostname = true
 			} else if len(tagValue) != 2 {
 				break
 			}

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -103,6 +103,20 @@ func TestStructuredDataParseExample4Fails(t *testing.T) {
 	}
 }
 
+func TestStructuredDataParseNoHostnameAllowed(t *testing.T) {
+	b := []byte(`[iut="3" eventSource="Application" eventID="1011"]`)
+	p := parser.StructuredData{}
+
+	c, err := p.Parse(b)
+	if err != nil {
+		t.Error("Expected parser to parse even though no hostname in data")
+		return
+	}
+	if c.Metrics[0].Data["iut"] != "3" {
+		t.Errorf("Expected structured data parser to return 3 for iut, but got %v", c.Metrics[0].Data["iut"])
+	}
+}
+
 func TestStructuredDataParseNoContentResultsInOneMetric(t *testing.T) {
 	b := []byte(`[exampleSDID@32473]`)
 	p := parser.StructuredData{}

--- a/parser/structured_data_test.go
+++ b/parser/structured_data_test.go
@@ -24,6 +24,7 @@
 package parser_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -48,7 +49,7 @@ func TestStructuredDataParseExample1(t *testing.T) {
 
 	data := c.Metrics[0].Data
 	if data["iut"] != "3" || data["eventSource"] != "Application" || data["eventID"] != "1011" {
-		t.Error("Failed to parse one or more params from the structured data")
+		t.Errorf("Failed to parse one or more params from the structured data, got: %v", c.Metrics[0].Data)
 	}
 }
 
@@ -87,20 +88,38 @@ func TestStructuredDataParseExample3Fails(t *testing.T) {
 	b := []byte(`[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] [examplePriority@32473 class="high"]`)
 	p := parser.StructuredData{}
 
-	if c, err := p.Parse(b); err == nil {
-		t.Errorf("Expected parser to fail for invalid format, got\n%+v", c)
+	c, err := p.Parse(b)
+	if err != nil {
+		t.Errorf("Expected parser to parse up until the invalid format, got err: %v", err)
 		return
+	}
+
+	if len(c.Metrics) != 1 {
+		t.Errorf("Expected to parse 1 metric, got %d", len(c.Metrics))
 	}
 }
 
-func TestStructuredDataParseExample4Fails(t *testing.T) {
+func TestStructuredDataParseExample4(t *testing.T) {
+	allowBracketSpace := true // https://datatracker.ietf.org/doc/html/draft-ietf-syslog-protocol-23#section-6.3.5 Example 4 *may* be allowed.
 	b := []byte(`[ exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`)
 	p := parser.StructuredData{}
 
-	if _, err := p.Parse(b); err == nil {
-		t.Error("Expected parser to fail for invalid format")
-		return
+	if allowBracketSpace {
+		c, err := p.Parse(b)
+		if err != nil {
+			t.Errorf("Expected parser to handle invalid format, err:%v", err)
+			return
+		}
+		if len(c.Metrics) != 2 {
+			t.Errorf("Expected parser to handle invalid format and parse 2 metrics, got %d", len(c.Metrics))
+		}
+	} else {
+		if _, err := p.Parse(b); err == nil {
+			t.Error("Expected parser to error on invalid format")
+			return
+		}
 	}
+
 }
 
 func TestStructuredDataParseNoHostnameAllowed(t *testing.T) {
@@ -117,13 +136,27 @@ func TestStructuredDataParseNoHostnameAllowed(t *testing.T) {
 	}
 }
 
+func TestStructuredDataParseNoHostnameAllowedMultipleMetrics(t *testing.T) {
+	b := []byte(`[iut="3" eventSource="Application" eventID="1011"]`)
+	p := parser.StructuredData{}
+
+	c, err := p.Parse([]byte(fmt.Sprintf("%s%s", b, b)))
+	if err != nil {
+		t.Error("Expected parser to parse even though no hostname in data")
+		return
+	}
+	if c.Metrics[0].Data["iut"] != "3" {
+		t.Errorf("Expected structured data parser to return 3 for iut, but got %v", c.Metrics[0].Data["iut"])
+	}
+}
+
 func TestStructuredDataParseNoContentResultsInOneMetric(t *testing.T) {
 	b := []byte(`[exampleSDID@32473]`)
 	p := parser.StructuredData{}
 
 	c, err := p.Parse(b)
 	if err != nil {
-		t.Error("Failed to parse data")
+		t.Errorf("Failed to parse data: %v", err)
 		return
 	}
 

--- a/parser/testdata/structured_data.txt
+++ b/parser/testdata/structured_data.txt
@@ -1,3 +1,4 @@
 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]
 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]
 [exampleSDID@32473]
+[foo="bar"]


### PR DESCRIPTION
f607809ec0d70780bab8c0612cc2d2059b9228c1 contains a fix and the following commits contain a cleanup/refactor of the whole parser.

The general idea of the refactor was to rework how metrics are parsed, as structured data entries are allowed in multiple forms, while the parser assumed one form and "accepted" the other. This fix, therefore, makes both forms first-class citizens.

The forms are

```
[foo@example key=val]
[bar@example key=val]
```

and 

```
[foo@example key=val][bar@example key=val]
```

and the original parser handled the first one by splitting on newlines but had to "add in" support for multiple entries on the same line. Now, this support is mainline.