### PR TITLE
feat(testing): Try to find a new port if the specified one is in use

### DIFF
--- a/receiver/common_test.go
+++ b/receiver/common_test.go
@@ -24,8 +24,16 @@
 package receiver_test
 
 import (
-	"github.com/telenornms/skogul"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/config"
+	"github.com/telenornms/skogul/receiver"
+	"github.com/telenornms/skogul/sender"
 )
 
 var validContainer = skogul.Container{}
@@ -40,4 +48,93 @@ func init() {
 	m.Metadata["foo"] = "bar"
 	m.Data["tall"] = 5
 	validContainer.Metrics = []*skogul.Metric{&m}
+}
+
+// UpdateHttpConfigWithUsablePorts updates the configuration with
+// ports that are available for use. This can be useful in a CI
+// environment where we don't care about the port number.
+// Note: We might end up with a port which is written in the test
+// as supposed to fail. ... left as an exercise for a future reader?
+// Note2: We only support HTTP receivers.
+func UpdateHttpConfigWithUsablePorts(config *config.Config) {
+	for key := range config.Receivers {
+		conf, ok := config.Receivers[key].Receiver.(*receiver.HTTP)
+		if !ok {
+			fmt.Println("failed to cast config to http")
+			continue
+		}
+		addr := conf.Address
+		origAddress := addr
+
+		add := strings.Split(addr, ":")[0]
+		port, _ := strconv.Atoi(strings.Split(addr, ":")[1])
+		for i := 0; i < 10; i++ { // only try 10 times
+			addr = fmt.Sprintf("%s:%d", add, port)
+			if sock, err := net.Listen("tcp", addr); err != nil {
+				// port might be in use, find another
+				port++
+			} else {
+				sock.Close()
+				break
+			}
+
+		}
+		conf.Address = addr
+		// fix senders
+		for key, send := range config.Senders {
+			if strings.ToLower(send.Type) != "http" {
+				continue
+			}
+
+			sConf, ok := config.Senders[key].Sender.(*sender.HTTP)
+			if !ok {
+				fmt.Println("failed to cast config to http sender")
+				continue
+			}
+			sConf.URL = strings.ReplaceAll(sConf.URL, origAddress, conf.Address)
+		}
+	}
+}
+
+// UpdateTcpConfigWithUsablePorts does the same as UpdateHttpConfigWithUsablePorts,
+// only that it does it for TCP instead...
+func UpdateTcpConfigWithUsablePorts(config *config.Config) {
+	for key := range config.Receivers {
+		conf, ok := config.Receivers[key].Receiver.(*receiver.TCPLine)
+		if !ok {
+			fmt.Println("failed to cast config to http")
+			continue
+		}
+		addr := conf.Address
+		origAddress := addr
+
+		add := strings.Split(addr, ":")[0]
+		port, _ := strconv.Atoi(strings.Split(addr, ":")[1])
+		for i := 0; i < 10; i++ { // only try 10 times
+			addr = fmt.Sprintf("%s:%d", add, port)
+			if sock, err := net.Listen("tcp", addr); err != nil {
+				// port might be in use, find another
+				port++
+			} else {
+				sock.Close()
+				break
+			}
+
+		}
+		conf.Address = addr
+		// fix senders
+		for key, send := range config.Senders {
+			if strings.ToLower(send.Type) != "net" {
+				continue
+			}
+
+			sConf, ok := config.Senders[key].Sender.(*sender.Net)
+			if !ok {
+				fmt.Println("failed to cast config to http sender")
+				continue
+			}
+			fmt.Println("updating", origAddress, conf.Address)
+			sConf.Address = strings.ReplaceAll(sConf.Address, origAddress, conf.Address)
+		}
+	}
 }

--- a/receiver/http_test.go
+++ b/receiver/http_test.go
@@ -173,6 +173,8 @@ func TestHttp_stack(t *testing.T) {
 		return
 	}
 
+	UpdateHttpConfigWithUsablePorts(config)
+
 	sPlainOrigin := config.Senders["plain_origin"].Sender.(*sender.HTTP)
 	sAuthPlainOrigin := config.Senders["auth_plain_origin"].Sender.(*sender.HTTP)
 	sAuthPlainFail1 := config.Senders["auth_plain_fail1"].Sender.(*sender.HTTP)

--- a/receiver/tcpline_test.go
+++ b/receiver/tcpline_test.go
@@ -25,11 +25,12 @@ package receiver_test
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/telenornms/skogul/config"
 	"github.com/telenornms/skogul/receiver"
 	"github.com/telenornms/skogul/sender"
-	"testing"
-	"time"
 )
 
 func TestTCPLine(t *testing.T) {
@@ -67,6 +68,8 @@ func TestTCPLine(t *testing.T) {
 		t.Errorf("Failed to load config: %v", err)
 		return
 	}
+
+	UpdateTcpConfigWithUsablePorts(conf)
 
 	sTest := conf.Senders["test"].Sender.(*sender.Test)
 	sNet := conf.Senders["net"].Sender


### PR DESCRIPTION
This should fix some of the tests we currently have where we try to listen on a port that might be unavailable in a CI environment.