### PR TITLE
Add optional burner to the batcher

### DIFF
--- a/docs/examples/burn-test/tester_to_udp.json
+++ b/docs/examples/burn-test/tester_to_udp.json
@@ -1,0 +1,34 @@
+{
+  "receivers": {
+    "test": {
+      "type": "test",
+      "handler": "json",
+      "metrics": 10,
+      "values": 10,
+      "threads": 30
+    }
+  },
+  "handlers": {
+    "json": {
+      "parser": "json",
+      "transformers": [],
+      "sender": "count"
+    },
+    "debugger": {
+	    "parser": "json",
+	    "sender": "print"
+    }
+  },
+  "senders": {
+    "count": {
+      "type": "count",
+      "stats": "debugger",
+      "next": "udp"
+    },
+    "udp": {
+      "type": "net",
+      "network": "udp",
+      "address": "[::1]:1337"
+    }
+  }
+}

--- a/docs/examples/burn-test/udp_count.json
+++ b/docs/examples/burn-test/udp_count.json
@@ -1,0 +1,76 @@
+{
+  "receivers": {
+      "udp": {
+        "type": "udp",
+        "address": "[::1]:1337",
+	"threads": 2,
+	"backlog": 1000,
+        "handler": "json"
+      }
+  },
+  "handlers": {
+    "json": {
+      "parser": "json",
+      "sender": "count"
+    },
+    "debugger": {
+      "parser": "json",
+      "transformers": [],
+      "sender": "print"
+    }
+  },
+  "senders": {
+    "batch": {
+      "type": "batch",
+      "threshold": 1000,
+      "next": "count"
+    },
+    "count": {
+      "type": "counter",
+      "stats": "debugger",
+      "next": "next"
+    },
+    "nextx": {
+	 "type": "batch",
+	 "next": "next"
+    },
+    "next": {
+	 "type": "dupe",
+	 "next": ["sleeper-b1", "sleeper-b2", "sleeper-slow"]
+    },
+    "sleeper-b1": {
+	 "type": "batch",
+	 "threshold": 1000,
+	 "next": "sleeper"
+    },
+    "sleeper-b2": {
+	 "type": "batch",
+	 "threshold": 1000,
+	 "next": "sleeper"
+    },
+    "sleeper-slow": {
+	 "type": "batch",
+	 "threshold": 1000,
+	 "burner": "burn",
+	 "next": "slowsleep"
+    },
+    "burn": {
+	 "type": "count",
+      "stats": "debugger",
+	 "next": "null"
+    },
+    "sleeper": {
+	 "type": "sleep",
+	 "maxdelay": "1ms",
+	 "next": "nil"
+    },
+    "slowsleep": {
+	 "type": "sleep",
+	 "maxdelay": "1s",
+	 "next": "nil"
+    },
+    "nil": {
+      "type": "null"
+    }
+  }
+}

--- a/sender/batch.go
+++ b/sender/batch.go
@@ -60,17 +60,17 @@ This means that:
 3. Send() will only block if two channels are full.
 */
 type Batch struct {
-	Next      skogul.SenderRef `doc:"Sender that will receive batched metrics"`
-	Interval  skogul.Duration  `doc:"Flush the bucket after this duration regardless of how full it is"`
-	Threshold int              `doc:"Flush the bucket after reaching this amount of metrics"`
-	Threads   int              `doc:"Number of threads for batch sender. Defaults to number of CPU cores."`
-	Burner	  skogul.SenderRef `doc:"If the next sender is too slow and containers pile up beyond the backlog, instead of blocking waiting for the regular sender, redirect the overflown data to this burner. If left blank, the batcher will block, waiting for the regular sender. Note that there is no secondary overflow protection, so if the burner-sender is slow as well, the batcher will still block. To just discard the data, just use the null-sender. To measure how frequently this happens, use the count-sender in combination with the null-sender."`
-	allocSize int // Precomputed of container to allocate initially
+	Next      skogul.SenderRef       `doc:"Sender that will receive batched metrics"`
+	Interval  skogul.Duration        `doc:"Flush the bucket after this duration regardless of how full it is"`
+	Threshold int                    `doc:"Flush the bucket after reaching this amount of metrics"`
+	Threads   int                    `doc:"Number of threads for batch sender. Defaults to number of CPU cores."`
+	Burner    skogul.SenderRef       `doc:"If the next sender is too slow and containers pile up beyond the backlog, instead of blocking waiting for the regular sender, redirect the overflown data to this burner. If left blank, the batcher will block, waiting for the regular sender. Note that there is no secondary overflow protection, so if the burner-sender is slow as well, the batcher will still block. To just discard the data, just use the null-sender. To measure how frequently this happens, use the count-sender in combination with the null-sender."`
+	allocSize int                    // Precomputed of container to allocate initially
 	ch        chan *skogul.Container // Initial channel used from Send()
 	once      sync.Once
 	timer     *time.Timer
-	cont      *skogul.Container // Current container - used single threaded
-	out       chan *skogul.Container // When Thershold/Timer is triggered, dump the container here
+	cont      *skogul.Container       // Current container - used single threaded
+	out       chan *skogul.Container  // When Thershold/Timer is triggered, dump the container here
 	burner    *chan *skogul.Container // Or burn it. Points to "out" if no burner is configured.
 }
 
@@ -153,9 +153,9 @@ func (bat *Batch) flusher(ch chan *skogul.Container, sender skogul.Sender) {
 // back to bat.out if no burner is present, thus block.
 func (bat *Batch) flush() {
 	select {
-		case bat.out <- bat.cont:
-		default:
-			*bat.burner <- bat.cont
+	case bat.out <- bat.cont:
+	default:
+		*bat.burner <- bat.cont
 	}
 	bat.cont = nil
 }

--- a/sender/batch.go
+++ b/sender/batch.go
@@ -64,13 +64,14 @@ type Batch struct {
 	Interval  skogul.Duration  `doc:"Flush the bucket after this duration regardless of how full it is"`
 	Threshold int              `doc:"Flush the bucket after reaching this amount of metrics"`
 	Threads   int              `doc:"Number of threads for batch sender. Defaults to number of CPU cores."`
-	allocSize int
-	ch        chan *skogul.Container
+	Burner	  skogul.SenderRef `doc:"If the next sender is too slow and containers pile up beyond the backlog, instead of blocking waiting for the regular sender, redirect the overflown data to this burner. If left blank, the batcher will block, waiting for the regular sender. Note that there is no secondary overflow protection, so if the burner-sender is slow as well, the batcher will still block. To just discard the data, just use the null-sender. To measure how frequently this happens, use the count-sender in combination with the null-sender."`
+	allocSize int // Precomputed of container to allocate initially
+	ch        chan *skogul.Container // Initial channel used from Send()
 	once      sync.Once
-	metrics   int
 	timer     *time.Timer
-	cont      *skogul.Container
-	out       chan *skogul.Container
+	cont      *skogul.Container // Current container - used single threaded
+	out       chan *skogul.Container // When Thershold/Timer is triggered, dump the container here
+	burner    *chan *skogul.Container // Or burn it. Points to "out" if no burner is configured.
 }
 
 func (bat *Batch) setup() {
@@ -95,7 +96,14 @@ func (bat *Batch) setup() {
 	}
 	bat.out = make(chan *skogul.Container, bat.Threads)
 	for i := 0; i < bat.Threads; i++ {
-		go bat.flusher()
+		go bat.flusher(bat.out, bat.Next.S)
+	}
+	if bat.Burner.Name != "" {
+		burner := make(chan *skogul.Container, bat.Threads)
+		bat.burner = &burner
+		go bat.flusher(burner, bat.Burner.S)
+	} else {
+		bat.burner = &bat.out
 	}
 	go bat.run()
 }
@@ -129,18 +137,26 @@ func (bat *Batch) add(c *skogul.Container) {
 
 // flusher fetches a ready-to-ship container and issues send(). One flusher
 // is run per NumCPU
-func (bat *Batch) flusher() {
+func (bat *Batch) flusher(ch chan *skogul.Container, sender skogul.Sender) {
 	for {
-		c := <-bat.out
-		err := bat.Next.S.Send(c)
+		c := <-ch
+		err := sender.Send(c)
 		if err != nil {
 			batchLog.WithError(err).Error(skogul.Error{Source: "batch sender", Reason: "down stream error", Next: err})
 		}
 	}
 }
 
+// flush is a "non-blocking" flush from the single-threaded part of the
+// batcher. It just dumps the container on to a channel, if the channel is
+// blocked, it will use an alternate channel. bat.burner will just point
+// back to bat.out if no burner is present, thus block.
 func (bat *Batch) flush() {
-	bat.out <- bat.cont
+	select {
+		case bat.out <- bat.cont:
+		default:
+			*bat.burner <- bat.cont
+	}
 	bat.cont = nil
 }
 


### PR DESCRIPTION
The burner sender can be used to "burn" metrics if the batcher would
otherwise end up blocking. The idea is to use this in scenarios where
you have multiple senders, where some is more important than others, or
you have alternate means of handling bursts of data (e.g.: queue it?).

I think the core mechanic is pretty elegant if I may say so myself, and
it's almost entirely unobtrusive. One could argue that the use of a
pointer to a channel is a bit intricate, I suppose.

I've tested various minor variations of this and seen no significant
improvement on the original. I'm also adding example configuration that
demonstrates the use. Run two skogul instances, one on each config in
docs/examples/burn-test. Try enabling/disabling the burner to see
significant performance differences.