### PR TITLE
Add CopyFromData to metadata transformer

### DIFF
--- a/transformer/auto.go
+++ b/transformer/auto.go
@@ -43,6 +43,7 @@ func init() {
 		Aliases: []string{},
 		Alloc:   func() interface{} { return &Metadata{} },
 		Help:    "Enforces custom-rules on metadata of metrics.",
+		Extras:  []interface{}{SourceDestination{}},
 	})
 	Auto.Add(skogul.Module{
 		Name:    "data",


### PR DESCRIPTION
So this basically duplicates what ExtractFromData does. Because of that,
it also "marks" ExtractFromData as obsolete, but only in documentation.
This can probably be discussed.

It's simple enough though: Copy fields from data to metadata, optionally
rename them and optionally delete the original.

Fixes #201 