### PR TITLE
feat: Publish container images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,6 +37,21 @@ steps:
     event:
     - tag
 
+- name: publish-container-image
+  image: plugins/docker
+  settings:
+    username: telenornms
+    password:
+      from_secret: github_release_api_key
+    repo: ghcr.io/telenornms/skogul
+    tags: ${DRONE_TAG}
+    registry: ghcr.io
+  depends_on:
+    - test
+  when:
+    event:
+    - tag
+
 - name: prepare-centos-release
   image: rockylinux:8
   environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:latest
 
+LABEL org.opencontainers.image.source https://github.com/telenornms/skogul
+
 RUN mkdir -p src
 
 WORKDIR src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:latest
+
+RUN mkdir -p src
+
+WORKDIR src
+
+COPY go.mod go.sum ./
+
+COPY . .
+
+RUN make skogul
+
+ENTRYPOINT ["./skogul"]


### PR DESCRIPTION
This change in the CI/CD pipeline will publish container images to GitHub Container Regsitry (https://ghcr.io). I tested it on a fork, https://github.com/sklirg/skogul, with successful builds\[0\] generating the package/container image https://github.com/users/sklirg/packages/container/package/skogul.

```
$ docker pull ghcr.io/sklirg/skogul
Using default tag: latest
latest: Pulling from sklirg/skogul
Digest: sha256:749effdb9e99c18aacf11347328b77a3e19b7fe10231421e2a8678e4cbfaa0e7
Status: Image is up to date for ghcr.io/sklirg/skogul:latest
ghcr.io/sklirg/skogul:latest
```

I've been running a self-built & self-hosted image for ~a month in kubernetes, and it works great. We're now running this in production over at Favrit, so it would be great to have an official image built from the source 👍 

\[0\]: https://cloud.drone.io/sklirg/skogul/10/1/4