### PR TITLE
feat(splunk): Send metadata as fields to Splunk HEC

### DIFF
--- a/sender/splunk.go
+++ b/sender/splunk.go
@@ -57,6 +57,7 @@ type splunkEvent struct {
 	Index  string                 `json:"index,omitempty"`
 	Source string                 `json:"source,omitempty"`
 	Event  map[string]interface{} `json:"event"`
+	Fields map[string]interface{} `json:"fields,omitempty"`
 }
 
 // prepare converts a skogul container into the appropriate
@@ -74,12 +75,14 @@ func (s *Splunk) prepare(c *skogul.Container) ([]splunkEvent, error) {
 		source := ""
 		if s.HostnameField != "" && metric.Metadata != nil && metric.Metadata[s.HostnameField] != nil {
 			host = fmt.Sprintf("%v", metric.Metadata[s.HostnameField])
+			delete(metric.Metadata, s.HostnameField)
 		}
 		if s.SourceField != "" && metric.Metadata != nil && metric.Metadata[s.SourceField] != nil {
 			source = fmt.Sprintf("%v", metric.Metadata[s.SourceField])
 			if source == "" {
 				source = s.Source
 			}
+			delete(metric.Metadata, s.SourceField)
 		}
 		events[i] = splunkEvent{
 			Time:   t,
@@ -87,6 +90,7 @@ func (s *Splunk) prepare(c *skogul.Container) ([]splunkEvent, error) {
 			Index:  s.Index,
 			Host:   host,
 			Source: source,
+			Fields: metric.Metadata,
 		}
 	}
 	return events, nil

--- a/sender/splunk_test.go
+++ b/sender/splunk_test.go
@@ -1,0 +1,65 @@
+package sender
+
+import (
+	"testing"
+
+	"github.com/telenornms/skogul"
+)
+
+func TestPrepare(t *testing.T) {
+	now := skogul.Now()
+
+	metadata := make(map[string]interface{})
+	metadata["source"] = "skogul"
+
+	data := make(map[string]interface{})
+	data["log"] = "some log"
+
+	metric := skogul.Metric{
+		Time:     &now,
+		Metadata: metadata,
+		Data:     data,
+	}
+
+	c := skogul.Container{
+		Metrics: []*skogul.Metric{&metric},
+	}
+
+	splunk := Splunk{}
+
+	_, err := splunk.prepare(&c)
+	if err != nil {
+		t.Errorf("failed to prepare splunk event: %s", err)
+	}
+}
+
+func TestPrepareSplunkMetadataAsFields(t *testing.T) {
+	now := skogul.Now()
+
+	metadata := make(map[string]interface{})
+	metadata["foo"] = "bar"
+
+	data := make(map[string]interface{})
+	data["log"] = "some log"
+
+	metric := skogul.Metric{
+		Time:     &now,
+		Metadata: metadata,
+		Data:     data,
+	}
+
+	c := skogul.Container{
+		Metrics: []*skogul.Metric{&metric},
+	}
+
+	splunk := Splunk{}
+
+	splunkEvents, err := splunk.prepare(&c)
+	if err != nil {
+		t.Errorf("failed to prepare splunk event: %s", err)
+	}
+
+	if splunkEvents[0].Fields["foo"] != "bar" {
+		t.Error("expected to find a 'field' named 'foo' with value 'bar' in splunkEvent")
+	}
+}


### PR DESCRIPTION
Following the documentation from Splunk HEC about field extractions
during indexing: https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/IFXandHEC#Add_a_fields_property_at_the_top_JSON_level

Before this change, fields in Metadata are silently ignored, and only fields in Data will be sent to splunk.

Fixes #242.
