### PR TITLE
feat(logs): Support configuring skogul to log as JSON

### DIFF
--- a/cmd/skogul/main.go
+++ b/cmd/skogul/main.go
@@ -58,6 +58,7 @@ var fconfigDir = flag.String("d", "", "Path to skogul configuration files. Depre
 var fhelp = flag.Bool("help", false, "Print more help")
 var fconf = flag.Bool("show", false, "Print the parsed JSON config instead of starting")
 var fman = flag.Bool("make-man", false, "Output RST documentation suited for rst2man")
+var flogformat = flag.String("logformat", "auto", "Log format (auto, json, default: auto)")
 var floglevel = flag.String("loglevel", "warn", "Minimum loglevel to display ([e]rror, [w]arn, [i]nfo, [d]ebug, [t]race/[v]erbose)")
 var ftimestamp = flag.Bool("timestamp", true, "Include timestamp in log entries")
 var fversion = flag.Bool("version", false, "Print skogul version")
@@ -119,7 +120,7 @@ func printVersion() {
 func main() {
 	flag.Parse()
 
-	skogul.ConfigureLogger(*floglevel, *ftimestamp)
+	skogul.ConfigureLogger(*floglevel, *ftimestamp, *flogformat)
 	log := skogul.Logger("cmd", "main")
 
 	if *fversion {

--- a/log.go
+++ b/log.go
@@ -33,7 +33,7 @@ import (
 var skogulLogger = logrus.New()
 
 // ConfigureLogger sets up the logger based on calling parameters
-func ConfigureLogger(requestedLoglevel string, logtimestamp bool) {
+func ConfigureLogger(requestedLoglevel string, logtimestamp bool, logFormat string) {
 	// Disable output from the root logger; all logging is delegated through hooks
 	logrus.SetLevel(logrus.TraceLevel)
 	logrus.SetOutput(ioutil.Discard)
@@ -41,9 +41,13 @@ func ConfigureLogger(requestedLoglevel string, logtimestamp bool) {
 	loglevel := GetLogLevelFromString(requestedLoglevel)
 	skogulLogger.SetLevel(loglevel)
 
-	skogulLogger.SetFormatter(&logrus.TextFormatter{
-		DisableTimestamp: !logtimestamp,
-	})
+	if strings.ToLower(logFormat) == "json" {
+		skogulLogger.SetFormatter(&logrus.JSONFormatter{})
+	} else {
+		skogulLogger.SetFormatter(&logrus.TextFormatter{
+			DisableTimestamp: !logtimestamp,
+		})
+	}
 
 	copyHook := LoggerCopyHook{
 		Writer: skogulLogger,


### PR DESCRIPTION
I only added support for JSON, and it will default to "auto" (... no matter what you type other than 'json').
I haven't heard of any request for forcing text mode or color mode, and assume that it works as people expect.
It should be pretty simple to add support for other formats as well if needed.
