### PR TITLE
chore: Deprecate 'json' alias for Skogul json parser

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -193,7 +193,7 @@ func TestParseInvalidContainerAndTransformItValid(t *testing.T) {
 	data := []byte(fmt.Sprintf(`{"data": 1, "ts": "%s"}`, timestring))
 
 	h := skogul.Handler{}
-	h.SetParser(parser.RawJSON{})
+	h.SetParser(parser.JSON{})
 
 	// Parse the data using the custom JSON handler
 	c, err := h.Parse(data)

--- a/common_test.go
+++ b/common_test.go
@@ -38,13 +38,13 @@ import (
 func TestHandler(t *testing.T) {
 	h1 := skogul.Handler{}
 	h2 := skogul.Handler{}
-	h2.SetParser(parser.JSON{})
+	h2.SetParser(parser.SkogulJSON{})
 	h3 := skogul.Handler{Transformers: []skogul.Transformer{}}
-	h3.SetParser(parser.JSON{})
+	h3.SetParser(parser.SkogulJSON{})
 	h4 := skogul.Handler{Transformers: []skogul.Transformer{}, Sender: &(sender.Test{})}
-	h4.SetParser(parser.JSON{})
+	h4.SetParser(parser.SkogulJSON{})
 	h5 := skogul.Handler{Transformers: []skogul.Transformer{nil}, Sender: &(sender.Test{})}
-	h5.SetParser(parser.JSON{})
+	h5.SetParser(parser.SkogulJSON{})
 
 	err := h1.Verify()
 	if err == nil {
@@ -100,9 +100,9 @@ func TestParseInvalidContainerSuccess(t *testing.T) {
 	data := []byte(`{"data": 1, "ts": "2020-01-01T00:00:00.0Z"}`)
 
 	h := skogul.Handler{}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 
-	// Verify that a JSON{} parser successfully parses this
+	// Verify that a SkogulJSON{} parser successfully parses this
 	// container even though it's not on the proper format
 	_, err := h.Parse(data)
 	if err != nil {
@@ -115,7 +115,7 @@ func TestParseAndTransformInvalidContainerFails(t *testing.T) {
 	data := []byte(`{"data": 1, "ts": "2020-01-01T00:00:00.0Z"}`)
 
 	h := skogul.Handler{}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 
 	c, err := h.Parse(data)
 	if err != nil {
@@ -136,7 +136,7 @@ func TestParseTransformAndSendInvalidContainerFails(t *testing.T) {
 	data := []byte(`{"data": 1, "ts": "2020-01-01T00:00:00.0Z"}`)
 
 	h := skogul.Handler{}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 
 	c, err := h.Parse(data)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestParseAndTransformInvalidContainerSuccess(t *testing.T) {
 	data := []byte(`{"metrics": [{ "metadata": {"foo":"bar"}}], "template": {"data": {"a": "b"}, "timestamp": "2020-01-01T00:00:00.0Z"}}`)
 
 	h := skogul.Handler{}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 
 	c, err := h.Parse(data)
 	if err != nil {

--- a/config/testdata/configs/valid2.json
+++ b/config/testdata/configs/valid2.json
@@ -7,7 +7,7 @@
     },
     "handlers": {
         "baz": {
-            "parser": "json",
+            "parser": "skogul",
             "sender": "qux"
         }
     },

--- a/config/testdata/test.json
+++ b/config/testdata/test.json
@@ -32,7 +32,7 @@
   },
   "handlers": {
     "plain": {
-      "parser": "json",
+      "parser": "skogul",
       "sender": "batch",
       "transformers": []
     }

--- a/data_test.go
+++ b/data_test.go
@@ -59,7 +59,7 @@ func TestString(t *testing.T) {
   ]
 }`
 	b := []byte(want)
-	j := parser.JSON{}
+	j := parser.SkogulJSON{}
 	c, err := j.Parse(b)
 	if err != nil {
 		t.Errorf("JSON.Parse(b) failed: %v", err)
@@ -144,7 +144,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestValidate_partial(t *testing.T) {
-	p := parser.JSON{}
+	p := parser.SkogulJSON{}
 	c, err := p.Parse([]byte(`{
 		"metrics": [
 			{

--- a/docs/benchmarking/conditional-config/benchmark-config.json
+++ b/docs/benchmarking/conditional-config/benchmark-config.json
@@ -9,12 +9,12 @@
   },
   "handlers": {
     "none": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "count"
     },
     "all": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [
         "interfaceexp_stats",
         "interface_stats",
@@ -31,14 +31,14 @@
       "sender": "count"
     },
     "conditional": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [
         "conditional-transform"
       ],
       "sender": "count"
     },
     "accounting": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "debug"
    }

--- a/docs/examples/basics/batch_burner.json
+++ b/docs/examples/basics/batch_burner.json
@@ -10,11 +10,11 @@
 	},
 	"handlers": {
 		"demo": {
-			"parser": "json",
+			"parser": "skogul",
 			"sender": "mybatch"
 		},
 		"stat": {
-			"parser": "json",
+			"parser": "skogul",
 			"sender": "print"
 		}
 	},

--- a/docs/examples/basics/batch_simple.json
+++ b/docs/examples/basics/batch_simple.json
@@ -11,7 +11,7 @@
 	},
 	"handlers": {
 		"demo": {
-			"parser": "json",
+			"parser": "skogul",
 			"sender": "mybatch"
 		}
 	},

--- a/docs/examples/basics/http_count.json
+++ b/docs/examples/basics/http_count.json
@@ -14,12 +14,12 @@
   },
   "handlers": {
     "jsontemplating": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [  ],
       "sender": "count"
     },
     "debugger": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "print"
     }

--- a/docs/examples/basics/https_basic_auth_count.json
+++ b/docs/examples/basics/https_basic_auth_count.json
@@ -18,12 +18,12 @@
   },
   "handlers": {
     "jsontemplating": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": ["templater"],
       "sender": "batch"
     },
     "debugger": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "print"
     }

--- a/docs/examples/basics/tester_to_stdout.json
+++ b/docs/examples/basics/tester_to_stdout.json
@@ -11,7 +11,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "print"
     }

--- a/docs/examples/client-certificates/client_certificates_skogul_config.json
+++ b/docs/examples/client-certificates/client_certificates_skogul_config.json
@@ -30,12 +30,12 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "http"
     },
     "debug": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "debug"
     }

--- a/docs/examples/enrichment/tester_to_stdout_enrich.json
+++ b/docs/examples/enrichment/tester_to_stdout_enrich.json
@@ -21,12 +21,12 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": ["someEnricher"],
       "sender": "print"
     },
     "update": {
-	"parser": "json",
+	"parser": "skogul",
 	"transformers": ["now"],
 	"sender": "updater"
     }

--- a/docs/examples/gob/tester_to_http_gob.json
+++ b/docs/examples/gob/tester_to_http_gob.json
@@ -11,7 +11,7 @@
 	},
 	"handlers": {
 		"something": {
-			"parser": "json",
+			"parser": "skogul",
 			"sender": "tohttps"
 		}
 	},

--- a/docs/examples/influxdb/http_to_influx.json
+++ b/docs/examples/influxdb/http_to_influx.json
@@ -10,7 +10,7 @@
   },
   "handlers": {
     "somejson": {
-      "parser": "json",
+      "parser": "skogul",
       "sender": "batch"
     }
   },

--- a/docs/examples/influxdb/https_influx.json
+++ b/docs/examples/influxdb/https_influx.json
@@ -18,7 +18,7 @@
   },
   "handlers": {
     "myjson": {
-      "parser": "json",
+      "parser": "skogul",
       "sender": "batch"
     }
   },

--- a/docs/examples/influxdb/tester_to_influxdb.json
+++ b/docs/examples/influxdb/tester_to_influxdb.json
@@ -10,7 +10,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "influxdb"
     }

--- a/docs/examples/juniper/transformers.json
+++ b/docs/examples/juniper/transformers.json
@@ -1,7 +1,7 @@
 {
   "handlers": {
     "juniperxform": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [
         "interfaceexp_stats",
         "interface_stats",

--- a/docs/examples/kafka/tester_to_kafka.json
+++ b/docs/examples/kafka/tester_to_kafka.json
@@ -11,7 +11,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "kaf"
     }

--- a/docs/examples/misc/mqtt_to_https.json
+++ b/docs/examples/misc/mqtt_to_https.json
@@ -11,7 +11,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "batch"
     }

--- a/docs/examples/misc/tester_to_file.json
+++ b/docs/examples/misc/tester_to_file.json
@@ -10,7 +10,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "file"
     }

--- a/docs/examples/misc/tester_to_http.json
+++ b/docs/examples/misc/tester_to_http.json
@@ -10,7 +10,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "http"
     }

--- a/docs/examples/misc/tester_to_https.json
+++ b/docs/examples/misc/tester_to_https.json
@@ -9,7 +9,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "batch"
     }

--- a/docs/examples/misc/tester_to_splunk_to_file.json
+++ b/docs/examples/misc/tester_to_splunk_to_file.json
@@ -17,7 +17,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": [],
       "sender": "splunk"
     },

--- a/docs/examples/misc/tester_to_switch.json
+++ b/docs/examples/misc/tester_to_switch.json
@@ -11,7 +11,7 @@
   },
   "handlers": {
     "json": {
-      "parser": "json",
+      "parser": "skogul",
       "transformers": ["keyText"],
       "sender": "switch"
     }

--- a/encoder/json_test.go
+++ b/encoder/json_test.go
@@ -80,7 +80,7 @@ func parseJSON(t *testing.T, file string) (*skogul.Container, []byte) {
 		t.FailNow()
 		return nil, nil
 	}
-	container, err := parser.JSON{}.Parse(b)
+	container, err := parser.SkogulJSON{}.Parse(b)
 
 	if err != nil {
 		t.Logf("Failed to parse JSON data: %v", err)

--- a/modules.go
+++ b/modules.go
@@ -23,6 +23,10 @@
 
 package skogul
 
+import (
+	log "github.com/sirupsen/logrus"
+)
+
 // Module is metadata for a skogul module. It is used by the receiver,
 // sender and transformer package. The Alloc() function must return a
 // data structure that implements the relevant module interface, which is
@@ -63,6 +67,11 @@ var Identity map[interface{}]string
 func (mm ModuleMap) Lookup(name string) *Module {
 	if mm[name] == nil {
 		return nil
+	}
+	// XXX: https://github.com/telenornms/skogul/issues/182
+	if name == "json" {
+		log.Warn("Parser 'json' is deprecated, use 'skogul' instead.")
+		return mm["skogul"]
 	}
 	if mm[name].AutoMake {
 		return mm[name]

--- a/parser/auto.go
+++ b/parser/auto.go
@@ -35,7 +35,7 @@ func init() {
 	Auto.Add(skogul.Module{
 		Name:     "skogul",
 		Aliases:  []string{"json"},
-		Alloc:    func() interface{} { return &JSON{} },
+		Alloc:    func() interface{} { return &SkogulJSON{} },
 		Help:     "Parses the standard Skogul JSON format.",
 		AutoMake: true,
 	})

--- a/parser/auto.go
+++ b/parser/auto.go
@@ -49,7 +49,7 @@ func init() {
 	Auto.Add(skogul.Module{
 		Name:     "rawjson",
 		Aliases:  []string{"jsonraw", "custom-json"},
-		Alloc:    func() interface{} { return &RawJSON{} },
+		Alloc:    func() interface{} { return &JSON{} },
 		Help:     "Parses any generic JSON data into a single metric which can then be potentially transformed into multiple metrics if need be.",
 		AutoMake: true,
 	})

--- a/parser/json.go
+++ b/parser/json.go
@@ -30,11 +30,12 @@ import (
 	"github.com/telenornms/skogul"
 )
 
-// JSON parses a byte string-representation of a Container
-type JSON struct{}
+// SkogulJSON parses a byte string-representation of a Container in the
+// format Skogul produces.
+type SkogulJSON struct{}
 
 // Parse accepts a byte slice of JSON data and marshals it into a container
-func (x JSON) Parse(b []byte) (*skogul.Container, error) {
+func (x SkogulJSON) Parse(b []byte) (*skogul.Container, error) {
 	container := skogul.Container{}
 	err := json.Unmarshal(b, &container)
 	return &container, err

--- a/parser/json.go
+++ b/parser/json.go
@@ -56,13 +56,16 @@ func (x JSONMetric) Parse(b []byte) (*skogul.Container, error) {
 	return &container, err
 }
 
-// RawJSON can be used when the JSON format does not conform to the final JSON format of skogul,
-// e.g. when it is used as the first step of parsing from a third party source where modifying
+// JSON is schemaless JSON. If data is sent between Skogul instances, SkogulJSON should be used instead
+// which retains the data structure Skogul works with. A distinction between 'Skogul' and 'JSON' is made
+// because historically, Skogul accepted 'json' as a configuration option for its own JSON format, now
+// named 'skogul'.
+// JSON can be useful e.g. as the first step of parsing from a third party source where modifying
 // the source data structure might be hard/impossible
-type RawJSON struct{}
+type JSON struct{}
 
 // Parse accepts a byte slice of JSON data and marshals it into an empty skogul.Container
-func (data RawJSON) Parse(b []byte) (*skogul.Container, error) {
+func (data JSON) Parse(b []byte) (*skogul.Container, error) {
 
 	// The Validate() func of a container expects a timestamp to be valid.
 	// Better way to fix?

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -33,18 +33,18 @@ import (
 
 // TestJSONParse tests parsing of a simple JSON document to skogul
 // container
-func TestJSONParse(t *testing.T) {
+func TestSkogulJSONParse(t *testing.T) {
 	b := []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
-	x := parser.JSON{}
+	x := parser.SkogulJSON{}
 	_, err := x.Parse(b)
 	if err != nil {
 		t.Errorf("JSON.Parse(b) failed: %s", err)
 	}
 }
 
-func BenchmarkJSONParse(b *testing.B) {
+func BenchmarkSkogulJSONParse(b *testing.B) {
 	by := []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
-	x := parser.JSON{}
+	x := parser.SkogulJSON{}
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -50,7 +50,7 @@ func BenchmarkSkogulJSONParse(b *testing.B) {
 	}
 }
 
-func TestRawJSONParse(t *testing.T) {
+func TestJSONParse(t *testing.T) {
 	b, err := ioutil.ReadFile("./testdata/raw.json")
 
 	if err != nil {
@@ -58,7 +58,7 @@ func TestRawJSONParse(t *testing.T) {
 		return
 	}
 
-	container, err := parser.RawJSON{}.Parse(b)
+	container, err := parser.JSON{}.Parse(b)
 
 	if err != nil {
 		t.Errorf("Failed to parse JSON data: %v", err)
@@ -71,7 +71,7 @@ func TestRawJSONParse(t *testing.T) {
 	}
 }
 
-func TestRawJSONArrayParse(t *testing.T) {
+func TestJSONArrayParse(t *testing.T) {
 	b, err := ioutil.ReadFile("./testdata/raw_array.json")
 
 	if err != nil {
@@ -79,7 +79,7 @@ func TestRawJSONArrayParse(t *testing.T) {
 		return
 	}
 
-	container, err := parser.RawJSON{}.Parse(b)
+	container, err := parser.JSON{}.Parse(b)
 
 	if err != nil {
 		t.Errorf("Failed to parse JSON data: %v", err)
@@ -92,9 +92,9 @@ func TestRawJSONArrayParse(t *testing.T) {
 	}
 }
 
-func BenchmarkRawJSONParse(b *testing.B) {
+func BenchmarkJSONParse(b *testing.B) {
 	by := []byte(`{"string":"text","float":1.11,"integer":5,"timestamp":"2019-03-15T11:08:02+01:00","key":"value"}`)
-	x := parser.RawJSON{}
+	x := parser.JSON{}
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}

--- a/receiver/examples_test.go
+++ b/receiver/examples_test.go
@@ -37,9 +37,9 @@ HTTP can have different skogul.Handler's for different paths, with potentially d
 func ExampleHTTP() {
 	h := receiver.HTTP{Address: "localhost:8080"}
 	template := skogul.Handler{Transformers: []skogul.Transformer{transformer.Templater{}}, Sender: &sender.Debug{}}
-	template.SetParser(parser.JSON{})
+	template.SetParser(parser.SkogulJSON{})
 	noTemplate := skogul.Handler{Sender: &sender.Debug{}}
-	noTemplate.SetParser(parser.JSON{})
+	noTemplate.SetParser(parser.SkogulJSON{})
 	h.Handlers = map[string]*skogul.HandlerRef{
 		"/template":   {H: &template},
 		"/notemplate": {H: &noTemplate},

--- a/receiver/tester_test.go
+++ b/receiver/tester_test.go
@@ -35,7 +35,7 @@ import (
 func TestTester_stack(t *testing.T) {
 	one := &(sender.Test{})
 	h := skogul.Handler{Sender: one}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 	rcv := receiver.Tester{Metrics: 10, Values: 5, Threads: 2, Handler: skogul.HandlerRef{H: &h}}
 	go rcv.Start()
 
@@ -54,7 +54,7 @@ func TestTester_stack(t *testing.T) {
 func TestTester_auto(t *testing.T) {
 	one := &(sender.Test{})
 	h := skogul.Handler{Sender: one}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 	parsedD, _ := time.ParseDuration("1s")
 	x := receiver.Tester{
 		Handler: skogul.HandlerRef{H: &h},

--- a/sender/complex_test.go
+++ b/sender/complex_test.go
@@ -58,7 +58,7 @@ func TestHttp_stack(t *testing.T) {
 	port := 1337 + rand.Intn(100)
 	adr := fmt.Sprintf("localhost:%d", port)
 	h := skogul.Handler{Sender: one}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 	rcv := receiver.HTTP{Address: adr, Handlers: map[string]*skogul.HandlerRef{"/": {H: &h}}}
 	//	rcv.Handle("/", &h)
 	go rcv.Start()

--- a/sender/counter_test.go
+++ b/sender/counter_test.go
@@ -36,7 +36,7 @@ func TestCounter(t *testing.T) {
 	two := &(sender.Test{})
 
 	h := skogul.Handler{Sender: one}
-	h.SetParser(parser.JSON{})
+	h.SetParser(parser.SkogulJSON{})
 	cnt := sender.Counter{Next: skogul.SenderRef{S: two}, Stats: skogul.HandlerRef{H: &h}, Period: skogul.Duration{Duration: time.Duration(50 * time.Millisecond)}}
 	two.TestQuick(t, &cnt, &validContainer, 1)
 	if one.Received() != 0 {

--- a/testdata/invalid_configs/conflict/http_no_user_pw.json
+++ b/testdata/invalid_configs/conflict/http_no_user_pw.json
@@ -8,7 +8,7 @@
 	},
 	"handlers": {
 		"dummy": {
-			"parser": "json",
+			"parser": "skogul",
 			"sender": "null"
 		}
 	}

--- a/testdata/invalid_configs/conflict/http_user_no_pw.json
+++ b/testdata/invalid_configs/conflict/http_user_no_pw.json
@@ -8,7 +8,7 @@
 	},
 	"handlers": {
 		"dummy": {
-			"parser": "json",
+			"parser": "skogul",
 			"sender": "null"
 		}
 	}

--- a/transformer/parse_test.go
+++ b/transformer/parse_test.go
@@ -42,7 +42,7 @@ func TestParseTransformer(t *testing.T) {
         }
     }]}`)
 
-	j := parser.JSON{}
+	j := parser.SkogulJSON{}
 	c, err := j.Parse(b)
 	if err != nil {
 		t.Errorf("Failed to parse container")
@@ -84,7 +84,7 @@ func TestParseTransformerAppend(t *testing.T) {
         }
     }]}`)
 
-	j := parser.JSON{}
+	j := parser.SkogulJSON{}
 	c, err := j.Parse(b)
 	if err != nil {
 		t.Errorf("Failed to parse container")


### PR DESCRIPTION
This change renames the currently existing JSON parsers.

The 'skogul JSON' parser is renamed (in code) to 'SkogulJSON', and in configuration it only accepts
"skogul" (instead of "skogul" and "json"). Using "json" still works, but produces a warning.

Following this, to avoid confusion in the code (mainly for new contributors), the existing 'RawJSON' struct
is renamed to 'JSON'. This might cause confusion for existing contributors used to 'JSON' being 'Skogul JSON',
but hopefully this won't be too bad. I did this change in a separate commit, so it is easy to drop this if we
want to keep the 'RawJSON' name (or if we want to change it to something else).

This is a start on the road of #182. I suggest a release or two before continuing. :-)
