### PR TITLE
chore: Replace more secret strings to secret type

### DIFF
--- a/receiver/http.go
+++ b/receiver/http.go
@@ -43,10 +43,10 @@ var httpLog = skogul.Logger("receiver", "http")
 
 // HTTPAuth contains ways to authenticate a HTTP request, e.g. Username/Password for Basic Auth.
 type HTTPAuth struct {
-	Username              string `doc:"Username for basic authentication. No authentication is required if left blank."`
-	Password              string `doc:"Password for basic authentication."`
-	SANDNSName            string `doc:"DNS name which has to be present in SAN extension of x509 certificate when using Client Certificate authentication"`
-	SkipCertificateVerify bool   `doc:"Skip verifying certificate. (default: false)"`
+	Username              string        `doc:"Username for basic authentication. No authentication is required if left blank."`
+	Password              skogul.Secret `doc:"Password for basic authentication."`
+	SANDNSName            string        `doc:"DNS name which has to be present in SAN extension of x509 certificate when using Client Certificate authentication"`
+	SkipCertificateVerify bool          `doc:"Skip verifying certificate. (default: false)"`
 	path                  string
 }
 
@@ -98,7 +98,7 @@ type httpReturn struct {
 func (auth *HTTPAuth) auth(r *http.Request) error {
 	if auth.Username != "" && auth.Password != "" {
 		username, pw, ok := r.BasicAuth()
-		success := ok && auth.Username == username && auth.Password == pw
+		success := ok && auth.Username == username && auth.Password.Expose() == pw
 		if !success {
 			return fmt.Errorf("Invalid credentials")
 		}

--- a/sender/splunk.go
+++ b/sender/splunk.go
@@ -38,13 +38,13 @@ var splunkLog = skogul.Logger("sender", "splunk")
 
 // Splunk contains the configuration parameters for this sender.
 type Splunk struct {
-	URL           string `doc:"URL to Splunk HTTP Event Collector (HEC)"`
-	Token         string `doc:"Token for HTTP Authorization header for HEC endpoint."`
-	Index         string `doc:"Custom Splunk index to send event to."`
-	HostnameField string `doc:"Name of the metadata field with the hostname. Note, this might have to be transformed into metadata depending on the input data."`
-	SourceField   string `doc:"Name of the metadata field with the source. Will fallback to the value set in Source if not found."`
-	Source        string `doc:"Set the source of the data. If used in conjunction with SourceField, SourceField will take precedence and this will be the fallback."`
-	HTTP          *HTTP  `doc:"HTTP sender options. URL is overwritten from this config, the rest will be HTTP sender defaults unless overridden."`
+	URL           string        `doc:"URL to Splunk HTTP Event Collector (HEC)"`
+	Token         skogul.Secret `doc:"Token for HTTP Authorization header for HEC endpoint."`
+	Index         string        `doc:"Custom Splunk index to send event to."`
+	HostnameField string        `doc:"Name of the metadata field with the hostname. Note, this might have to be transformed into metadata depending on the input data."`
+	SourceField   string        `doc:"Name of the metadata field with the source. Will fallback to the value set in Source if not found."`
+	Source        string        `doc:"Set the source of the data. If used in conjunction with SourceField, SourceField will take precedence and this will be the fallback."`
+	HTTP          *HTTP         `doc:"HTTP sender options. URL is overwritten from this config, the rest will be HTTP sender defaults unless overridden."`
 	ok            bool
 	once          sync.Once
 }
@@ -129,7 +129,7 @@ func (e *splunkEvent) MarshalJSON() ([]byte, error) {
 func (s *Splunk) init() {
 	s.HTTP.URL = s.URL
 	s.HTTP.init()
-	s.HTTP.Headers["authorization"] = fmt.Sprintf("Splunk %s", s.Token)
+	s.HTTP.Headers["authorization"] = fmt.Sprintf("Splunk %s", s.Token.Expose())
 	s.ok = s.HTTP.ok
 }
 
@@ -167,7 +167,7 @@ func (s *Splunk) Verify() error {
 	if s.URL == "" {
 		return skogul.MissingArgument("URL")
 	}
-	if s.Token == "" {
+	if s.Token.Expose() == "" {
 		return skogul.MissingArgument("Token")
 	}
 	if s.Index == "" {


### PR DESCRIPTION
This partially implements #186.

I am not currently able to test the Kafka sender and receiver, nor the MQTT ones, so I haven't touched those, but as shown in these changes, it should be pretty straightforward to test and verify.

Some other senders and receivers should be discussed;

* HTTP: 
  * Custom headers, e.g. `Authorization` or custom headers such as `X-API-Key` are not covered. They may contain credentials, and their contents might be shown in the log output. I'm not sure of a good "secure-first" way of doing this, other than masking _all_ headers, which can make it hard to debug.
  * The URL might contain credentials, e.g. `http://user:pass@host`. This is not masked.
* SQL: We can mask the full connection string, but this can make it harder to debug connection issues. As the connection string and query string are different, this might be a worthwhile change.