### PR TITLE
fix: Allow GitHub Actions ample time to run specific tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,5 @@ jobs:
         go-version: ${{ matrix.go-version }}
         cache: true
     - run: make check
+      env:
+        SKOGUL_TEST_SLEEP_DURATION: 10s


### PR DESCRIPTION
See example usage in 0a2aec73b117ac63572c62fba0e2b1a57a5fcf07 and in the workflow updated