### PR TITLE
feat(build): Add runtime image based on Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:latest AS builder
 
 LABEL org.opencontainers.image.source https://github.com/telenornms/skogul
 
@@ -12,4 +12,13 @@ COPY . .
 
 RUN make skogul
 
-ENTRYPOINT ["./skogul"]
+# Runtime
+FROM debian:stable-slim
+
+RUN apt update && apt install -y \
+	ca-certificates
+
+COPY --from=builder /go/src/skogul /usr/local/bin/skogul
+COPY --from=builder /go/src/docs/examples/basics/default.json /etc/skogul/conf.d/default.json
+
+ENTRYPOINT ["skogul", "-loglevel=i"]


### PR DESCRIPTION
This PR adds a "runtime image" to the current Dockerfile. I decided to do this as a separate change to the one by @n-holmstedt in #277, considering that #277 adds a completely new Dockerfile. If this is accepted, most of my comments in that PR can be disregarded as well :-)

This change adds a "runtime image" to the Dockerfile which is what will be published to the Container Registry. This "runtime image" is based on Debian, instead of being the full Golang build environment. This reduces its size a bit as you can see in the comparison below. This also reduces the potential attack surface of exploiting tools inside the build environment.

I decided to change the default command from simply starting Skogul (which would lead to an error message about missing a configuration file), to launching the default Skogul configuration from docs/examples, as well as changing the log-level. This provides better feedback for someone trying to spin up Skogul as a container, as it would otherwise be completely silent (but listening on the port specified in default config).

All of this can be overridden, e.g. by providing another config file to Skogul (such as through volumes) and/or by altering the startup command.

---

Size difference:
\<none\> is an image built using this change,
ghcr.io/telenornms/skogul is v0.18.0 from GHCR.

```
$ podman image ls | grep -e skogul -e e7e56
<none>                                         <none>                    e7e5619d2654  About a minute ago  147 MB
ghcr.io/telenornms/skogul                      v0.18.0                   b10226d1676a  3 months ago        1.07 GB
```