### PR TITLE
Split by all parent keys if fields has only one empty string

### DIFF
--- a/transformer/split_test.go
+++ b/transformer/split_test.go
@@ -38,7 +38,7 @@ func TestSplit(t *testing.T) {
 		"metrics": [
 		{
 			"data": {
-				"data": [
+				"data1": [
 				{
 					"splitField": "key1",
 					"data": "yes"
@@ -49,7 +49,6 @@ func TestSplit(t *testing.T) {
 				}
 				]
 			}
-
 		},
 		{
 			"data": {
@@ -58,7 +57,7 @@ func TestSplit(t *testing.T) {
 		},
 		{
 			"data": {
-				"data": [
+				"data1": [
 				{
 					"splitField": "key3",
 					"data": "2yes"
@@ -78,7 +77,7 @@ func TestSplit(t *testing.T) {
 		return
 	}
 
-	split_path := "data"
+	split_path := ""
 	metadata := transformer.Split{
 		Field:        []string{split_path},
 		MetadataName: "arrayidx",


### PR DESCRIPTION
Adds the ability to split all metrics by parent keys, when fields is "" and only has one value. Not splitting in depth.
This change should be backwards compatible by default.