### PR TITLE
Fix NATS worker queue

### DIFF
--- a/receiver/nats.go
+++ b/receiver/nats.go
@@ -51,6 +51,7 @@ type Nats struct {
 	NKeyFile      string            `doc:"Nats nkey file path"`
 	Insecure      bool              `doc:"TLS InsecureSkipVerify"`
 	conOpts       *[]nats.Option
+	natsSub       *nats.Subscription
 	natsCon       *nats.Conn
 	wg            sync.WaitGroup
 }

--- a/receiver/nats.go
+++ b/receiver/nats.go
@@ -154,8 +154,8 @@ func (n *Nats) Start() error {
 		natsLog.Debugf("Starting queued subscription on %v with queue %v", n.Subject, n.Queue)
 		n.natsSub, err = n.natsCon.QueueSubscribe(n.Subject, n.Queue, cb)
 	} else {
-			natsLog.Debugf("Starting subscription on %v", n.Subject)
-			n.natsSub, err = n.natsCon.Subscribe(n.Subject, cb)
+		natsLog.Debugf("Starting subscription on %v", n.Subject)
+		n.natsSub, err = n.natsCon.Subscribe(n.Subject, cb)
 	}
 
 	if err != nil {

--- a/receiver/nats.go
+++ b/receiver/nats.go
@@ -149,11 +149,19 @@ func (n *Nats) Start() error {
 	}
 
 	n.wg.Add(1)
-	if n.Queue == "" {
-		n.natsCon.QueueSubscribe(n.Subject, n.Queue, cb)
+	if len(n.Queue) > 0 {
+		natsLog.Debugf("Starting queued subscription on %v with queue %v", n.Subject, n.Queue)
+		n.natsSub, err = n.natsCon.QueueSubscribe(n.Subject, n.Queue, cb)
 	} else {
-		n.natsCon.Subscribe(n.Subject, cb)
+			natsLog.Debugf("Starting subscription on %v", n.Subject)
+			n.natsSub, err = n.natsCon.Subscribe(n.Subject, cb)
 	}
+
+	if err != nil {
+		n.wg.Done()
+		return err
+	}
+
 	n.wg.Wait()
 	return n.natsCon.LastError()
 }


### PR DESCRIPTION
Bug in the worker queue setting causing all messages under the same subject to be load balanced under "emtpy string".

Also, slight change of error logging.