### PR TITLE
chore: remove macos tests from ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The tests running on macos have become flaky due to internal github server issues causing these runtimes to be slow.
See e.g. https://github.com/actions/runner-images/issues/11509

Since skogul tests take execution speed into account this slowness causes random tests to fail without a good reason since we're not aiming to run skogul on macos environments in production.