### PR TITLE
fix: benchmark timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,42 @@ test:
 
 bench:
 	@echo 🏋 Benchmarking
-	@go test -run ^Bench -benchtime 1s -bench Bench ./... | grep Benchmark
+	@go test -run ^Bench -benchtime 1s -bench Bench ./... | grep --line-buffered Benchmark | awk -v term_width=$$(tput cols 2>/dev/null || echo 120) 'BEGIN { \
+		num_width = 13; \
+		spacing = 2; \
+		fixed_width = (num_width * 4) + (spacing * 4); \
+		name_width = term_width - fixed_width; \
+		if (name_width < 30) name_width = 30; \
+		if (name_width > 60) name_width = 60; \
+		fmt_name = "%-" name_width "s"; \
+		fmt_num = "%" num_width "s"; \
+		printf fmt_name " " fmt_num " " fmt_num " " fmt_num " " fmt_num "\n", "Test", "Iterations", "ns/op", "B/op", "allocs/op"; \
+		printf fmt_name " " fmt_num " " fmt_num " " fmt_num " " fmt_num "\n", "----", "----------", "-----", "----", "---------"; \
+		fflush(); \
+	} { \
+		name = $$1; \
+		sub(/^Benchmark/, "", name); \
+		sub(/ProtoBuf/, "PB", name); \
+		sub(/InfluxDB/, "Influx", name); \
+		sub(/MemoryFootprint/, "Mem", name); \
+		sub(/WithoutTimestamp/, "NoTS", name); \
+		sub(/SmallMessage/, "Small", name); \
+		sub(/LargeMessage/, "Large", name); \
+		iters = $$2; \
+		ns = $$3; \
+		bytes = "-"; \
+		allocs = "-"; \
+		for (i = 4; i <= NF; i++) { \
+			if ($$i == "B/op" && i > 4) { \
+				bytes = $$(i-1); \
+			} \
+			if ($$i == "allocs/op" && i > 4) { \
+				allocs = $$(i-1); \
+			} \
+		} \
+		printf fmt_name " " fmt_num " " fmt_num " " fmt_num " " fmt_num "\n", name, iters, ns, bytes, allocs; \
+		fflush(); \
+	}'
 
 covergui:
 	@echo 🧠 Testing, with coverage analysis

--- a/data_test.go
+++ b/data_test.go
@@ -199,6 +199,8 @@ func BenchmarkValidate(b *testing.B) {
 	metric.Time = &now
 	okc := skogul.Container{}
 	okc.Metrics = []*skogul.Metric{&metric}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		okc.Validate(false)
 	}
@@ -208,6 +210,8 @@ func BenchmarkValidate(b *testing.B) {
 func BenchmarkCompareText(b *testing.B) {
 	data := []string{"the fox jumps over the some-variable=na something", "this is fine, nothing is on fire", "only 1337 allowed"}
 	str := "only 1337 allowed"
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for x := 0; x < 3; x++ {
 			if data[x] == str {
@@ -222,6 +226,8 @@ func BenchmarkCompareRegexp(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Couldn't compile regexp: %v", err)
 	}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for x := 0; x < 3; x++ {
 			if exp.Match([]byte(data[x])) {
@@ -232,6 +238,8 @@ func BenchmarkCompareRegexp(b *testing.B) {
 }
 func BenchmarkCompareSubstr(b *testing.B) {
 	data := []string{"the fox jumps over the some-variable=na something", "this is fine, nothing is on fire", "only 1337 allowed"}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for x := 0; x < 3; x++ {
 			if strings.Contains(data[x], "1337") {

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -6,7 +6,7 @@ package gen
 //go:generate /bin/bash -c "rm -f junos/telemetry/*pb.go; mkdir -p junos/telemetry"
 //go:generate /bin/bash -c "tar xzf tar-balls/junos-telemetry-interface-23.2R1.tar.gz"
 //go:generate /bin/bash -c "for a in junos-telemetry-interface/*.proto; do if echo $DOLLAR{a} | egrep -qv '/(gnmi|sr_|Gnmi)'; then protoc --gogo_out=junos/telemetry --gogo_opt=M=$DOLLAR{PWD}junos-telemetry-interface/ -Ijunos-telemetry-interface/ $DOLLAR{a}; else echo skipping $DOLLAR{a}; fi; done"
-//go:generate /bin/bash -c "sed -i 's/^package.*/package telemetry/g' junos/telemetry/*.go"
+//go:generate /bin/bash -c "sed -i.bak 's/^package.*/package telemetry/g' junos/telemetry/*.go && rm junos/telemetry/*.go.bak"
 
 //go:generate /bin/bash -c "rm -f usp/*pb.go; mkdir -p usp"
 //go:generate /bin/bash -c "tar xf tar-balls/usp-interface-1-1.tar.gz"

--- a/parser/influxdb_test.go
+++ b/parser/influxdb_test.go
@@ -302,6 +302,8 @@ func TestInfluxDBParseTelegrafCmdLines(t *testing.T) {
 func BenchmarkInfluxDBLineParse(b *testing.B) {
 	by := []byte(`disk,device=sda1,fstype=fat32,host=testhost,mode=rw,path=/private/var/vm free=98896670720i,used=1073762304i,used_percent=1.0740798769394355,inodes_total=4882452880i,total=499963174912i 1585737350000000000`)
 	x := parser.InfluxDB{}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}
@@ -310,6 +312,8 @@ func BenchmarkInfluxDBLineParse(b *testing.B) {
 func BenchmarkInfluxDBLineParseWithoutTimestamp(b *testing.B) {
 	by := []byte(`disk,device=sda1,fstype=fat32,host=testhost,mode=rw,path=/private/var/vm free=98896670720i,used=1073762304i,used_percent=1.0740798769394355,inodes_total=4882452880i,total=499963174912i`)
 	x := parser.InfluxDB{}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}

--- a/parser/json_test.go
+++ b/parser/json_test.go
@@ -45,6 +45,8 @@ func TestSkogulJSONParse(t *testing.T) {
 func BenchmarkSkogulJSONParse(b *testing.B) {
 	by := []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
 	x := parser.SkogulJSON{}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}
@@ -95,6 +97,8 @@ func TestJSONArrayParse(t *testing.T) {
 func BenchmarkJSONParse(b *testing.B) {
 	by := []byte(`{"string":"text","float":1.11,"integer":5,"timestamp":"2019-03-15T11:08:02+01:00","key":"value"}`)
 	x := parser.JSON{}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		x.Parse(by)
 	}

--- a/parser/mnr_test.go
+++ b/parser/mnr_test.go
@@ -191,6 +191,8 @@ func TestMNROnDataset(t *testing.T) {
 func BenchmarkMNRParse(b *testing.B) {
 	line := []byte("1599730066	group	127.0.0.1.ifXTable..1.12.RATEP.Pkts/s.820424119	0.0	key=1")
 	x := parser.MNR{}
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		x.Parse(line)
 	}

--- a/receiver/http_test.go
+++ b/receiver/http_test.go
@@ -403,6 +403,7 @@ func BenchmarkHttp_json(b *testing.B) {
 	sPlainOrigin := bConfig.Senders["plain_origin"].Sender.(*sender.HTTP)
 	sCommon := bConfig.Senders["common"].Sender.(*sender.Test)
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, sPlainOrigin, &validContainer, 10, 10)
 	}
@@ -412,6 +413,7 @@ func BenchmarkHttp_ssl_json(b *testing.B) {
 	sPlainOrigin := bConfig.Senders["ssl_auth"].Sender.(*sender.HTTP)
 	sCommon := bConfig.Senders["common"].Sender.(*sender.Test)
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, sPlainOrigin, &validContainer, 10, 10)
 	}
@@ -421,6 +423,7 @@ func BenchmarkHttp_batch_json(b *testing.B) {
 	sPlainBatch := bConfig.Senders["plain_batch"].Sender
 	sCommon := bConfig.Senders["common"].Sender.(*sender.Test)
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, sPlainBatch, &validContainer, 100, 1)
 	}
@@ -430,6 +433,7 @@ func BenchmarkHttp_nobatch_json(b *testing.B) {
 	sPlainNoBatch := bConfig.Senders["plain_origin"].Sender
 	sCommon := bConfig.Senders["common"].Sender.(*sender.Test)
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, sPlainNoBatch, &validContainer, 100, 100)
 	}
@@ -439,6 +443,7 @@ func BenchmarkHttp_ssl_nobatch_json(b *testing.B) {
 	sSSL := bConfig.Senders["ssl_auth"].Sender
 	sCommon := bConfig.Senders["common"].Sender.(*sender.Test)
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, sSSL, &validContainer, 100, 100)
 	}
@@ -448,6 +453,7 @@ func BenchmarkHttp_ssl_batch_json(b *testing.B) {
 	sSSL := bConfig.Senders["ssl_auth_batch"].Sender
 	sCommon := bConfig.Senders["common"].Sender.(*sender.Test)
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, sSSL, &validContainer, 100, 1)
 	}

--- a/receiver/udp_test.go
+++ b/receiver/udp_test.go
@@ -43,6 +43,9 @@ var u1 *net.UDPConn
 var u2 *net.UDPConn
 var u3 *net.UDPConn
 var u4 *net.UDPConn
+var u5 *net.UDPConn
+var u6 *net.UDPConn
+var u7 *net.UDPConn
 var pJSON = []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
 
 func readProtobufFile(file string) []byte {
@@ -105,6 +108,27 @@ func init() {
 			"handler": "json-sleep",
 			"Threads": 100,
 			"Buffer": 1024
+		},
+		"udp5": {
+			"type": "udp",
+			"address": "localhost:1989",
+			"handler": "json",
+			"Threads": 1,
+			"Buffer": 65536
+		},
+		"udp6": {
+			"type": "udp",
+			"address": "localhost:1999",
+			"handler": "json",
+			"Threads": 10,
+			"Buffer": 65536
+		},
+		"udp7": {
+			"type": "udp",
+			"address": "localhost:2009",
+			"handler": "json",
+			"Threads": 100,
+			"Buffer": 65536
 		}
 	},
 	"handlers": {
@@ -117,6 +141,11 @@ func init() {
 			"parser": "json",
 			"transformers": [],
 			"sender": "sleep"
+		},
+		"json": {
+			"parser": "json",
+			"transformers": [],
+			"sender": "common"
 		}
 	}
 }`))
@@ -130,6 +159,9 @@ func init() {
 	var udpAddr2 *net.UDPAddr
 	var udpAddr3 *net.UDPAddr
 	var udpAddr4 *net.UDPAddr
+	var udpAddr5 *net.UDPAddr
+	var udpAddr6 *net.UDPAddr
+	var udpAddr7 *net.UDPAddr
 	udpAddr1, err = net.ResolveUDPAddr("udp", "localhost:1939")
 	if err != nil {
 		fmt.Printf("Failed to resolve: %v\n", err)
@@ -146,6 +178,21 @@ func init() {
 		os.Exit(1)
 	}
 	udpAddr4, err = net.ResolveUDPAddr("udp", "localhost:1979")
+	if err != nil {
+		fmt.Printf("Failed to resolve: %v\n", err)
+		os.Exit(1)
+	}
+	udpAddr5, err = net.ResolveUDPAddr("udp", "localhost:1989")
+	if err != nil {
+		fmt.Printf("Failed to resolve: %v\n", err)
+		os.Exit(1)
+	}
+	udpAddr6, err = net.ResolveUDPAddr("udp", "localhost:1999")
+	if err != nil {
+		fmt.Printf("Failed to resolve: %v\n", err)
+		os.Exit(1)
+	}
+	udpAddr7, err = net.ResolveUDPAddr("udp", "localhost:2009")
 	if err != nil {
 		fmt.Printf("Failed to resolve: %v\n", err)
 		os.Exit(1)
@@ -174,15 +221,39 @@ func init() {
 		os.Exit(1)
 	}
 	u4.SetWriteBuffer(9000)
+	u5, err = net.DialUDP("udp", nil, udpAddr5)
+	if err != nil {
+		fmt.Printf("Failed to dial: %v\n", err)
+		os.Exit(1)
+	}
+	u5.SetWriteBuffer(9000)
+	u6, err = net.DialUDP("udp", nil, udpAddr6)
+	if err != nil {
+		fmt.Printf("Failed to dial: %v\n", err)
+		os.Exit(1)
+	}
+	u6.SetWriteBuffer(9000)
+	u7, err = net.DialUDP("udp", nil, udpAddr7)
+	if err != nil {
+		fmt.Printf("Failed to dial: %v\n", err)
+		os.Exit(1)
+	}
+	u7.SetWriteBuffer(9000)
 
 	rUDP1 := uConfig.Receivers["udp1"].Receiver.(*receiver.UDP)
 	rUDP2 := uConfig.Receivers["udp2"].Receiver.(*receiver.UDP)
 	rUDP3 := uConfig.Receivers["udp3"].Receiver.(*receiver.UDP)
 	rUDP4 := uConfig.Receivers["udp4"].Receiver.(*receiver.UDP)
+	rUDP5 := uConfig.Receivers["udp5"].Receiver.(*receiver.UDP)
+	rUDP6 := uConfig.Receivers["udp6"].Receiver.(*receiver.UDP)
+	rUDP7 := uConfig.Receivers["udp7"].Receiver.(*receiver.UDP)
 	go rUDP1.Start()
 	go rUDP2.Start()
 	go rUDP3.Start()
 	go rUDP4.Start()
+	go rUDP5.Start()
+	go rUDP6.Start()
+	go rUDP7.Start()
 	time.Sleep(time.Duration(100 * time.Millisecond))
 }
 
@@ -232,7 +303,7 @@ func BenchmarkUDP_protobuf(b *testing.B) {
 
 func BenchmarkUDP_json_Threads1(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
-	ds := &dummyJSONSender{u2, 20}
+	ds := &dummyJSONSender{u5, 20}
 	sCommon.SetSync(true)
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
@@ -241,7 +312,7 @@ func BenchmarkUDP_json_Threads1(b *testing.B) {
 
 func BenchmarkUDP_json_Threads10(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
-	ds := &dummyJSONSender{u3, 20}
+	ds := &dummyJSONSender{u6, 20}
 	sCommon.SetSync(true)
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
@@ -250,7 +321,7 @@ func BenchmarkUDP_json_Threads10(b *testing.B) {
 
 func BenchmarkUDP_json_Threads100(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
-	ds := &dummyJSONSender{u4, 20}
+	ds := &dummyJSONSender{u7, 20}
 	sCommon.SetSync(true)
 	for i := 0; i < b.N; i++ {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)

--- a/receiver/udp_test.go
+++ b/receiver/udp_test.go
@@ -25,28 +25,31 @@ package receiver_test
 
 import (
 	"fmt"
-	"github.com/telenornms/skogul"
-	"github.com/telenornms/skogul/config"
-	"github.com/telenornms/skogul/receiver"
-	"github.com/telenornms/skogul/sender"
 	"net"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/config"
+	"github.com/telenornms/skogul/receiver"
+	"github.com/telenornms/skogul/sender"
 )
 
 // FIXME: This file is very fond of global scope and init(), mainly for the
 // sake of benchmarks... and it's a bit messy.
-var uConfig *config.Config
-var pFile []byte
-var u1 *net.UDPConn
-var u2 *net.UDPConn
-var u3 *net.UDPConn
-var u4 *net.UDPConn
-var u5 *net.UDPConn
-var u6 *net.UDPConn
-var u7 *net.UDPConn
-var pJSON = []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
+var (
+	uConfig *config.Config
+	pFile   []byte
+	u1      *net.UDPConn
+	u2      *net.UDPConn
+	u3      *net.UDPConn
+	u4      *net.UDPConn
+	u5      *net.UDPConn
+	u6      *net.UDPConn
+	u7      *net.UDPConn
+	pJSON   = []byte("{\"metrics\":[{\"timestamp\":\"2019-03-15T11:08:02+01:00\",\"metadata\":{\"key\":\"value\"},\"data\":{\"string\":\"text\",\"float\":1.11,\"integer\":5}}]}")
+)
 
 func readProtobufFile(file string) []byte {
 	b := make([]byte, 9000)
@@ -149,7 +152,6 @@ func init() {
 		}
 	}
 }`))
-
 	if err != nil {
 		fmt.Printf("Failed to load config: %v", err)
 		os.Exit(1)
@@ -264,11 +266,13 @@ func sendUDP(u *net.UDPConn, b []byte) {
 	}
 }
 
-type dummySender struct{}
-type dummyJSONSender struct {
-	sock       *net.UDPConn
-	iterations int
-}
+type (
+	dummySender     struct{}
+	dummyJSONSender struct {
+		sock       *net.UDPConn
+		iterations int
+	}
+)
 
 func (d *dummyJSONSender) Send(c *skogul.Container) error {
 	for i := 0; i < d.iterations; i++ {
@@ -296,7 +300,7 @@ func BenchmarkUDP_protobuf(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummySender{}
 	sCommon.SetSync(true)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 10, 10)
 	}
 }
@@ -305,7 +309,7 @@ func BenchmarkUDP_json_Threads1(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummyJSONSender{u5, 20}
 	sCommon.SetSync(true)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
 	}
 }
@@ -314,7 +318,7 @@ func BenchmarkUDP_json_Threads10(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummyJSONSender{u6, 20}
 	sCommon.SetSync(true)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
 	}
 }
@@ -323,7 +327,7 @@ func BenchmarkUDP_json_Threads100(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummyJSONSender{u7, 20}
 	sCommon.SetSync(true)
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
 	}
 }

--- a/receiver/udp_test.go
+++ b/receiver/udp_test.go
@@ -300,6 +300,7 @@ func BenchmarkUDP_protobuf(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummySender{}
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 10, 10)
 	}
@@ -309,6 +310,7 @@ func BenchmarkUDP_json_Threads1(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummyJSONSender{u5, 20}
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
 	}
@@ -318,6 +320,7 @@ func BenchmarkUDP_json_Threads10(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummyJSONSender{u6, 20}
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
 	}
@@ -327,6 +330,7 @@ func BenchmarkUDP_json_Threads100(b *testing.B) {
 	sCommon := uConfig.Senders["common"].Sender.(*sender.Test)
 	ds := &dummyJSONSender{u7, 20}
 	sCommon.SetSync(true)
+	b.ReportAllocs()
 	for b.Loop() {
 		sCommon.TestSync(b, ds, &validContainer, 5, 100)
 	}

--- a/timer_test.go
+++ b/timer_test.go
@@ -53,12 +53,16 @@ func TestNow(t *testing.T) {
 }
 
 func BenchmarkTimeNow(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		time.Now()
 	}
 }
 
 func BenchmarkSkogulNow(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		skogul.Now()
 	}

--- a/transformer/enrich_test.go
+++ b/transformer/enrich_test.go
@@ -52,6 +52,8 @@ func BenchmarkHash(b *testing.B) {
 	m.Metadata["key1"] = "a car"
 	m.Metadata["key2"] = "lol kek bikes rock"
 
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		e.Hash(m)
 	}


### PR DESCRIPTION
Benchmarking skogul with `make bench` hangs indefinitely after `BenchmarkUDP_json_Threads1`.

Fixes benchmark timeouts in UDP receiver tests by separating benchmark configuration from test configuration. Benchmarks now use direct receivers without artificial sleep delays, while tests maintain sleep delays to simulate network latency.

  | Metric | Before | After |
  |--------|--------|-------|
  | Time per iteration | 188ms | 1.3ms |
  | Iterations per run | 6 then hung | 900+ |
  | Full make bench | Hung | 2 minutes |
