### PR TITLE
Set CGO_ENABLED=0 for static binary compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ARCH := $(shell uname -m)
 
 skogul: $(wildcard *.go */*.go */*/*.go)
 	@echo 🤸 go build !
-	@go build -ldflags "-X main.versionNo=${VERSION_NO}" -o skogul ./cmd/skogul
+	@CGO_ENABLED=0 go build -ldflags "-X main.versionNo=${VERSION_NO}" -o skogul ./cmd/skogul
 
 docs/skogul.rst: skogul
 	@echo 😽 Generating documentation$@

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,24 @@
 # DESTDIR can be used to prefix ALL paths, e.g., to do a dummy-install in a
 # fake root dir, e.g., for building packages. Users mainly want PREFIX
 
-PREFIX=/usr/local
-DOCDIR=${PREFIX}/share/doc/skogul
+PREFIX = /usr/local
+DOCDIR = ${PREFIX}/share/doc/skogul
 
-GIT_DESCRIBE:=$(shell git describe --always --tag --dirty)
-VERSION_NO=$(shell echo ${GIT_DESCRIBE} | sed s/[v-]//g)
-OS:=$(shell uname -s | tr A-Z a-z)
-ARCH:=$(shell uname -m)
+GIT_DESCRIBE := $(shell git describe --always --tag --dirty)
+VERSION_NO = $(shell echo ${GIT_DESCRIBE} | sed s/[v-]//g)
+OS := $(shell uname -s | tr A-Z a-z)
+ARCH := $(shell uname -m)
 
 skogul: $(wildcard *.go */*.go */*/*.go)
 	@echo 🤸 go build !
 	@go build -ldflags "-X main.versionNo=${VERSION_NO}" -o skogul ./cmd/skogul
 
 docs/skogul.rst: skogul
-	@echo 😽 Generating documentation $@
+	@echo 😽 Generating documentation$@
 	@./skogul -make-man > $@
 
 skogul.1: docs/skogul.rst
-	@echo 🎢 Generating man-file $@
+	@echo 🎢 Generating man-file$@
 	@rst2man < $< > $@
 
 notes: docs/NEWS
@@ -33,18 +33,18 @@ install: skogul skogul.1 docs/skogul.rst
 	@install -D -m 0755 skogul ${DESTDIR}${PREFIX}/bin/skogul
 	@install -D -m 0644 skogul.1 ${DESTDIR}${PREFIX}/share/man/man1/skogul.1
 	@install -D -m 0644 docs/examples/basics/default.json ${DESTDIR}/etc/skogul/conf.d/default.json
-	@cd docs; \
-	find . -type f -exec install -D -m 0644 {} ${DESTDIR}${DOCDIR}/{} \;
+	@cd docs
+	find . -type f -exec install -D -m 0644 {}${DESTDIR}${DOCDIR}/{} \;
 	@install -D -m 0644 README.rst LICENSE -t ${DESTDIR}${DOCDIR}/
-
-
-FORCE:
 
 # Any complaints on this macro-substitution without patches and I introduce m4.
 build/redhat-skogul.spec: build/redhat-skogul.spec.in FORCE
-	@echo  ❕Building spec-file
+	@echo ❕Building spec-file
 	@cat $< | sed "s/xxVxx/${GIT_DESCRIBE}/g; s/xxARCHxx/${ARCH}/g; s/xxVERSION_NOxx/${VERSION_NO}/g" > $@
-	@if [ ! -f /etc/redhat-release ]; then echo 🆒 Adding debian-workaround for rpm build; sed -i 's/^BuildReq/\#Debian hack, auto-commented out: BuildReq/g' $@; fi
+	@if [ ! -f /etc/redhat-release ]; then \
+		echo 🆒 Adding debian-workaround for rpm build; \
+		sed -i 's/^BuildReq/\#Debian hack, auto-commented out: BuildReq/g'$@; \
+	fi
 
 # Build RPM. The spec has a blank %prep, so it assumes sources are already
 # available. This isn't perfect, since it creates a tight coupling between
@@ -54,22 +54,22 @@ build/redhat-skogul.spec: build/redhat-skogul.spec.in FORCE
 rpm: build/redhat-skogul.spec
 	@echo 🎇 Triggering huge-as-heck rpm build
 	@mkdir -p rpm-prep/BUILDROOOT
-	@DEFAULT_UNIT_DIR=/usr/lib/systemd/system ;\
-	RPM_UNIT_DIR=$$(rpm --eval $%{_unitdir}) ;\
+	@DEFAULT_UNIT_DIR=/usr/lib/systemd/system ; \
+	RPM_UNIT_DIR=$$(rpm --eval $%{_unitdir}) ; \
 	if [ "$${RPM_UNIT_DIR}" = "$%{_unitdir}" ]; then \
-	    echo "😭 _unitdir not set, setting _unitdir to $$DEFAULT_UNIT_DIR"; \
-	    rpmbuild --quiet --bb \
-	        --nodebuginfo \
-	    	--build-in-place \
+		echo "😭 _unitdir not set, setting _unitdir to $$DEFAULT_UNIT_DIR"; \
+		rpmbuild --quiet --bb \
+		--nodebuginfo \
+		--build-in-place \
 		--define "_rpmdir $$(pwd)" \
 		--define "_topdir $$(pwd)" \
 		--define "_unitdir $$DEFAULT_UNIT_DIR" \
 		--buildroot "$$(pwd)/rpm-prep/BUILDROOT" \
 		build/redhat-skogul.spec; \
 	else \
-	    rpmbuild --quiet --bb \
-	        --nodebuginfo \
-	    	--build-in-place \
+		rpmbuild --quiet --bb \
+		--nodebuginfo \
+		--build-in-place \
 		--define "_rpmdir $$(pwd)" \
 		--define "_topdir $$(pwd)" \
 		--buildroot "$$(pwd)/rpm-prep/BUILDROOT" \
@@ -80,19 +80,16 @@ rpm: build/redhat-skogul.spec
 
 check: test fmtcheck vet exampletest exampletestdep checkconfigs printfcheck
 
-# Can't for the life of me remember where this came from and it's seemingly
-# gone now, so removed from check.
-lint:
-	@echo 🐉 Linting code
-	@golint -set_exit_status
-
 vet:
 	@echo 🔬 Vetting code
 	@go vet ./...
 
 fmtcheck:
 	@echo 🦉 Checking format with gofmt -d -s
-	@if [ "x$$(find . -name '*.go' -not -wholename './gen/*' -and -not -wholename './vendor/*' -exec gofmt -d -s {} +)" != "x" ]; then find . -name '*.go' -not -wholename './gen/*' -and -not -wholename './vendor/*' -exec gofmt -d -s {} +; exit 1; fi
+	@if [ "x$$(find . -name '*.go' -not -wholename './gen/*' -and -not -wholename './vendor/*' -exec gofmt -d -s {} +)" != "x" ]; then \
+	find . -name '*.go' -not -wholename './gen/*' -and -not -wholename './vendor/*' -exec gofmt -d -s {} +; \
+		exit 1; \
+	fi
 
 fmtfix:
 	@echo 🎨 Fixing formating
@@ -108,16 +105,16 @@ exampletest: skogul
 		./skogul -show -f $$a >/dev/null 2>&1 ; \
 		if [ $$? -ne 0 ]; then \
 			echo 🚩 Example $$a is not valid; \
-			failed=$$(( failed + 1 ));\
-		fi;\
-	done;\
+			failed=$$(( failed + 1 )); \
+		fi; \
+	done; \
 	exit $${failed}
 	@echo 📖 Verifying junos example
-	@./skogul -show -d docs/examples/juniper >/dev/null 2>&1 ; \
+	@./skogul -show -d docs/examples/juniper >/dev/null 2>&1; \
 	if [ $$? -ne 0 ]; then \
 		echo 🚩 Junos-example is not valid; \
-		exit 1;\
-	fi;
+		exit 1; \
+	fi
 
 checkbadconfigs: skogul
 	@echo 📖 Verifying that invalid configuration files are caught
@@ -125,9 +122,9 @@ checkbadconfigs: skogul
 		./skogul -show -f $$a >/dev/null 2>&1 ; \
 		if [ $$? -eq 0 ]; then \
 			echo 🚩 Invalid config $$a was accepted, but should fail; \
-			failed=$$(( failed + 1 ));\
-		fi;\
-	done;\
+			failed=$$(( failed + 1 )); \
+		fi; \
+	done; \
 	exit $${failed}
 
 checkokconfigs: skogul
@@ -136,9 +133,9 @@ checkokconfigs: skogul
 		./skogul -show -f $$a >/dev/null 2>&1 ; \
 		if [ $$? -ne 0 ]; then \
 			echo 🚩 Valid config $$a was rejected; \
-			failed=$$(( failed + 1 ));\
-		fi;\
-	done;\
+			failed=$$(( failed + 1 )); \
+		fi; \
+	done; \
 	exit $${failed}
 
 checkconfigs: checkbadconfigs checkokconfigs
@@ -149,16 +146,16 @@ exampletestdep: exampletest
 		./skogul -show -f $$a 2>&1 | egrep -q "deprecation warning for" ; \
 		if [ $$? -eq 0 ]; then \
 			echo 🚩 Example $$a has deprecation warnings; \
-			failed=$$(( failed + 1 ));\
-		fi;\
-	done;\
+			failed=$$(( failed + 1 )); \
+		fi; \
+	done; \
 	exit $${failed}
 	@echo 📖 Checking junos example for deprecation warnings
-	@./skogul -show -d docs/examples/juniper 2>&1 | egrep -q 'deprecation warning for' ; \
+	@./skogul -show -d docs/examples/juniper 2>&1 | egrep -q 'deprecation warning for'; \
 	if [ $$? -eq 0 ]; then \
 		echo 🚩 Junos-example has deprecation warnings; \
-		exit 1;\
-	fi;
+		exit 1; \
+	fi
 
 test:
 	@echo 🧐 Testing, without SQL-tests
@@ -190,7 +187,7 @@ clean:
 
 help:
 	@echo "Several targets(🎯) exist:"
-	@echo 
+	@echo
 	@echo " - skogul - build the binary (the default)"
 	@echo " - all - build binary and documentation"
 	@echo " - install - install binary and docs. Honors PREFIX, default prefix: ${PREFIX}"
@@ -204,4 +201,4 @@ help:
 	@echo " - fmtfix - Runs gofmt -d -s -w, excluding generated code (e.g.: fix formating)"
 	@echo " - covergui - Run tests, track test coverage and open coverage analysis in browser"
 
-.PHONY: clean test bench help install rpm release
+.PHONY: all clean check checkconfigs test bench help install rpm release


### PR DESCRIPTION
Add `CGO_ENABLED=0` to build command in Makefile

The codebase contains no CGO usage and all dependencies are pure Go implementations:
  - SQL drivers (go-sql-driver/mysql, lib/pq) are pure Go
  - No C library bindings present
  - No `import "C"` statements in codebase

Benefits
  - Improved portability across different Linux distributions and versions
  - Simplified container deployments and cross-compilation
  - Reduced binary size and attack surface

Also did some formatting of the Makefile with [bake](https://github.com/EbodShojaei/bake), a makefile formatter for readability and some very minor cleanup.