### PR TITLE
Minor fixes in the protobuf parsers

### DIFF
--- a/gen/.gitignore
+++ b/gen/.gitignore
@@ -1,0 +1,2 @@
+*.proto
+junos-telemetry-interface/

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -3,12 +3,4 @@
 // (re)generate the files.
 package gen
 
-//go:generate /bin/bash -c "rm -f junos/telemetry/*pb.go; mkdir -p junos/telemetry"
-//go:generate /bin/bash -c "tar xzf tar-balls/junos-telemetry-interface-23.2R1.tar.gz"
-//go:generate /bin/bash -c "for a in junos-telemetry-interface/*.proto; do if echo $DOLLAR{a} | egrep -qv '/(gnmi|sr_|Gnmi)'; then protoc --gogo_out=junos/telemetry --gogo_opt=M=$DOLLAR{PWD}junos-telemetry-interface/ -Ijunos-telemetry-interface/ $DOLLAR{a}; else echo skipping $DOLLAR{a}; fi; done"
-//go:generate /bin/bash -c "sed -i.bak 's/^package.*/package telemetry/g' junos/telemetry/*.go && rm junos/telemetry/*.go.bak"
-
-//go:generate /bin/bash -c "rm -f usp/*pb.go; mkdir -p usp"
-//go:generate /bin/bash -c "tar xf tar-balls/usp-interface-1-1.tar.gz"
-//go:generate /bin/bash -c "protoc --gogo_out=usp --gogo_opt=M=${PWD}/usp usp-record-1-1.proto"
-//go:generate /bin/bash -c "protoc --gogo_out=usp --gogo_opt=M=${PWD}/usp usp-msg-1-1.proto"
+//go:generate ./generate.sh

--- a/gen/generate.sh
+++ b/gen/generate.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Script to regenerate protobuf code for Junos telemetry and USP interfaces
+# This script handles both GNU sed (Linux) and BSD sed (macOS)
+
+set -e
+
+cd "$(dirname "$0")"
+
+# Cross-platform in-place sed
+# BSD sed (macOS) requires -i '' while GNU sed requires just -i
+sed_inplace() {
+    if sed --version 2>/dev/null | grep -q GNU; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+echo "Generating Junos telemetry protobuf code..."
+
+# Clean and prepare output directory
+rm -f junos/telemetry/*pb.go
+mkdir -p junos/telemetry
+
+# Extract proto files
+tar xzf tar-balls/junos-telemetry-interface-23.2R1.tar.gz
+
+# Generate Go code from proto files, skipping gnmi/sr_/Gnmi patterns
+for a in junos-telemetry-interface/*.proto; do
+    if echo "${a}" | grep -Eqv '/(gnmi|sr_|Gnmi)'; then
+        protoc --gogo_out=junos/telemetry --gogo_opt=M="${PWD}/junos-telemetry-interface/" -Ijunos-telemetry-interface/ "${a}"
+    else
+        echo "skipping ${a}"
+    fi
+done
+
+# Fix package names in generated files
+sed_inplace 's/^package.*/package telemetry/g' junos/telemetry/*.go
+
+echo "Generating USP protobuf code..."
+
+# Clean and prepare output directory
+rm -f usp/*pb.go
+mkdir -p usp
+
+# Extract proto files
+tar xf tar-balls/usp-interface-1-1.tar.gz
+
+# Generate Go code
+protoc --gogo_out=usp --gogo_opt=M="${PWD}/usp" usp-record-1-1.proto
+protoc --gogo_out=usp --gogo_opt=M="${PWD}/usp" usp-msg-1-1.proto
+
+echo "Done!"

--- a/parser/protobuf_junos.go
+++ b/parser/protobuf_junos.go
@@ -125,8 +125,8 @@ func parseTelemetryStream(protobuffer []byte) (*pb.TelemetryStream, error) {
 
 // createMetadata extracts the fields containing metadata from the protocol buffer
 // and stores them in a string-interface map to be consumed at a later stage.
-func (x *ProtoBuf) createMetadata(telemetry *pb.TelemetryStream) (map[string]interface{}, error) {
-	metadata := make(map[string]interface{})
+func (x *ProtoBuf) createMetadata(telemetry *pb.TelemetryStream) (map[string]any, error) {
+	metadata := make(map[string]any)
 
 	metadata["systemId"] = telemetry.GetSystemId()
 	metadata["sensorName"] = telemetry.GetSensorName()
@@ -190,7 +190,7 @@ createData creates a string-interface map of skogul.Metric type Data
 by first marshalling the protobuf message into json and then parsing
 it back in to a string-interface map.
 */
-func (x *ProtoBuf) createData(telemetry *pb.TelemetryStream) (map[string]interface{}, error) {
+func (x *ProtoBuf) createData(telemetry *pb.TelemetryStream) (map[string]any, error) {
 	extension, err := proto.GetExtension(telemetry.GetEnterprise(), pb.E_JuniperNetworks)
 	if err != nil {
 		atomic.AddUint64(&x.stats.MissingExtension, 1)
@@ -251,7 +251,7 @@ func (x *ProtoBuf) createData(telemetry *pb.TelemetryStream) (map[string]interfa
 		return nil, fmt.Errorf("found no valid extensions")
 	}
 
-	var metrics map[string]interface{}
+	var metrics map[string]any
 	if err = json.Unmarshal(jsonMessage, &metrics); err != nil {
 		atomic.AddUint64(&x.stats.FailedToJsonUnmarshal, 1)
 		target := 500
@@ -283,8 +283,8 @@ func (x *ProtoBuf) GetStats() *skogul.Metric {
 	now := skogul.Now()
 	metric := skogul.Metric{
 		Time:     &now,
-		Metadata: make(map[string]interface{}),
-		Data:     make(map[string]interface{}),
+		Metadata: make(map[string]any),
+		Data:     make(map[string]any),
 	}
 	metric.Metadata["component"] = "parser"
 	metric.Metadata["type"] = "protobuf"

--- a/parser/protobuf_junos.go
+++ b/parser/protobuf_junos.go
@@ -38,6 +38,10 @@ import (
 	pb "github.com/telenornms/skogul/gen/junos/telemetry"
 )
 
+// infinityReplacementDbm is used to replace -Inf optics power values
+// with a reasonable floor value (-40 dBm) for JSON compatibility.
+const infinityReplacementDbm float32 = -40.0
+
 var pbLog = skogul.Logger("parser", "protobuf")
 
 // ProtoBuf parses a byte string-representation of a Container
@@ -137,7 +141,7 @@ applyJuniperHaxx adjusts incoming telemetry packets to make them JSON-compatible
 So far, it's mainly about fixing -Inf.
 */
 func applyJuniperHaxx(messageOnly proto.Message) {
-	var foo float32 = -40.0
+	replacement := infinityReplacementDbm
 	optics, ok := messageOnly.(*pb.Optics)
 	if !ok {
 		return
@@ -169,12 +173,12 @@ func applyJuniperHaxx(messageOnly proto.Message) {
 		for _, lane := range odiags.OpticsDiagStats.OpticsLaneDiagStats {
 			if lane.LaneLaserReceiverPowerDbm != nil {
 				if skogul.IsInf(*lane.LaneLaserReceiverPowerDbm, -1) {
-					lane.LaneLaserReceiverPowerDbm = &foo
+					lane.LaneLaserReceiverPowerDbm = &replacement
 				}
 			}
 			if lane.LaneLaserOutputPowerDbm != nil {
 				if skogul.IsInf(*lane.LaneLaserOutputPowerDbm, -1) {
-					lane.LaneLaserOutputPowerDbm = &foo
+					lane.LaneLaserOutputPowerDbm = &replacement
 				}
 			}
 		}

--- a/parser/protobuf_junos.go
+++ b/parser/protobuf_junos.go
@@ -270,7 +270,6 @@ func (x *ProtoBuf) createData(telemetry *pb.TelemetryStream) (map[string]interfa
 	delete(metrics, "componentId")
 	delete(metrics, "subComponentId")
 
-	atomic.AddUint64(&x.stats.Parsed, 1)
 	return metrics, nil
 }
 

--- a/parser/protobuf_junos_test.go
+++ b/parser/protobuf_junos_test.go
@@ -46,7 +46,7 @@ const (
 )
 
 type failer interface {
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 	Helper()
 }
 
@@ -83,7 +83,7 @@ func TestProtoBuf(t *testing.T) {
 func BenchmarkProtoBufParse(b *testing.B) {
 	by := readProtobufFile(b, "testdata/protobuf-packet.bin")
 	x := parser.ProtoBuf{}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		x.Parse(by)
 	}
 }
@@ -133,20 +133,20 @@ func generateOpticsDiag(val float32) junos_protobuf_telemetry.TelemetryStream {
 	return generateJunosTelemetryStream("foo", eps)
 }
 
-func parseDiagStatsResp(data map[string]interface{}, key string) interface{} {
-	opticsDiag, ok := data["Optics_diag"].([]interface{})
+func parseDiagStatsResp(data map[string]any, key string) any {
+	opticsDiag, ok := data["Optics_diag"].([]any)
 	if !ok {
 		fmt.Printf("failed to cast")
 	}
-	foo, ok := opticsDiag[0].(map[string]interface{})
+	foo, ok := opticsDiag[0].(map[string]any)
 	if !ok {
 		fmt.Printf("failed to cast 2")
 	}
-	opticsDiagStats := foo["optics_diag_stats"].(map[string]interface{})
+	opticsDiagStats := foo["optics_diag_stats"].(map[string]any)
 
-	opticsLaneDiagStats := opticsDiagStats["optics_lane_diag_stats"].([]interface{})
+	opticsLaneDiagStats := opticsDiagStats["optics_lane_diag_stats"].([]any)
 
-	bar, ok := opticsLaneDiagStats[0].(map[string]interface{})
+	bar, ok := opticsLaneDiagStats[0].(map[string]any)
 	if !ok {
 		fmt.Printf("failed to cast 3")
 	}

--- a/parser/protobuf_junos_test.go
+++ b/parser/protobuf_junos_test.go
@@ -175,6 +175,11 @@ func TestParseJunosProtobufTelemetryStreamOptics(t *testing.T) {
 	}
 	if c == nil {
 		t.Error("Protobuf parse returned nil-container")
+		return
+	}
+	if len(c.Metrics) == 0 {
+		t.Error("Protobuf parse returned container with no metrics")
+		return
 	}
 
 	got := parseDiagStatsResp(c.Metrics[0].Data, "lane_laser_receiver_power_dbm")

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -117,8 +117,8 @@ func (p *USPParser) getRecordMsgPayload(payload []byte) (*usp.Msg, error) {
 }
 
 // createRecordMetadata creates a map[string]interface{} of the metadata for skogul.Metric
-func (p *USPParser) createRecordMetadata(h *usp.Record, xh map[string]interface{}) map[string]interface{} {
-	d := make(map[string]interface{})
+func (p *USPParser) createRecordMetadata(h *usp.Record, xh map[string]any) map[string]any {
+	d := make(map[string]any)
 
 	d["event"] = xh["event"]
 	d["event_type"] = xh["event_type"]
@@ -133,10 +133,10 @@ func (p *USPParser) createRecordMetadata(h *usp.Record, xh map[string]interface{
 }
 
 // extractJSON unmarshals event parameters to json
-func (p *USPParser) extractJSON(s string) (map[string]interface{}, error) {
+func (p *USPParser) extractJSON(s string) (map[string]any, error) {
 	input := []byte(s)
 
-	var d map[string]interface{}
+	var d map[string]any
 
 	if err := json.Unmarshal(input, &d); err != nil {
 		return nil, err
@@ -146,8 +146,8 @@ func (p *USPParser) extractJSON(s string) (map[string]interface{}, error) {
 }
 
 // createRecordData creates a map[string]interface{} of the record payload for skogul.Metric
-func (p *USPParser) createRecordData(t *usp.Record) (map[string]interface{}, error) {
-	jsonMap := make(map[string]interface{})
+func (p *USPParser) createRecordData(t *usp.Record) (map[string]any, error) {
+	jsonMap := make(map[string]any)
 	payload, err := p.getRecordMsgPayload(t.GetNoSessionContext().GetPayload())
 	if err != nil {
 		return nil, err
@@ -171,8 +171,8 @@ func (p *USPParser) GetStats() *skogul.Metric {
 	now := skogul.Now()
 	metric := skogul.Metric{
 		Time:     &now,
-		Metadata: make(map[string]interface{}),
-		Data:     make(map[string]interface{}),
+		Metadata: make(map[string]any),
+		Data:     make(map[string]any),
 	}
 	metric.Metadata["component"] = "parser"
 	metric.Metadata["type"] = "usp"

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -154,8 +154,8 @@ func (p *USPParser) createRecordData(t *usp.Record) (map[string]any, error) {
 	}
 
 	// Check if request contains the Notify event. (It could be a different event by mistake)
-	if d, ok := payload.Body.GetRequest().GetReqType().(*usp.Request_Notify); !ok {
-		return nil, fmt.Errorf("invalid event %s", d.Notify.GetEvent())
+	if _, ok := payload.Body.GetRequest().GetReqType().(*usp.Request_Notify); !ok {
+		return nil, fmt.Errorf("request does not contain a Notify event")
 	}
 
 	jsonMap["event"] = payload.GetBody().GetRequest().GetNotify().GetEvent().GetObjPath()

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -92,7 +92,7 @@ func (p *USPParser) Parse(b []byte) (*skogul.Container, error) {
 	return &container, nil
 }
 
-// getUspRecord Unmarshals []byte into a protoc generated struct and returns it
+// getUspRecord Unmarshals []byte into a protoc generated struct
 func (p *USPParser) getUspRecord(d []byte) (*usp.Record, error) {
 	unmarshaledMessage := &usp.Record{}
 	if err := proto.Unmarshal(d, unmarshaledMessage); err != nil {
@@ -167,7 +167,7 @@ func (p *USPParser) createRecordData(t *usp.Record) (map[string]interface{}, err
 }
 
 // GetStats prepares a skogul metric with stats for the USP parser.
-func (p *USP_Parser) GetStats() *skogul.Metric {
+func (p *USPParser) GetStats() *skogul.Metric {
 	now := skogul.Now()
 	metric := skogul.Metric{
 		Time:     &now,

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -59,7 +59,13 @@ func (p *USPParser) Parse(b []byte) (*skogul.Container, error) {
 
 	metadata := p.createRecordMetadata(record, recordData)
 
-	json, err := p.extractJSON(recordData["event_data"].(string))
+	eventData, ok := recordData["event_data"].(string)
+	if !ok {
+		atomic.AddUint64(&p.stats.FailedToJsonUnmarshal, 1)
+		return nil, errors.New("event_data is missing or not a string")
+	}
+
+	json, err := p.extractJSON(eventData)
 	if err != nil {
 		atomic.AddUint64(&p.stats.FailedToJsonUnmarshal, 1)
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
@@ -94,11 +100,10 @@ func (p *USPParser) getUspRecord(d []byte) (*usp.Record, error) {
 
 /*
 getRecordMsgPayload unmarshals []byte consisting of the record payload into
-a protoc generated struct and returns it
+a protoc generated struct
 */
 func (p *USPParser) getRecordMsgPayload(payload []byte) (*usp.Msg, error) {
 	msgPayload := &usp.Msg{}
-
 	if err := proto.Unmarshal(payload, msgPayload); err != nil {
 		atomic.AddUint64(&p.stats.ParseErrors, 1)
 		return nil, fmt.Errorf("failed to unmarshal payload: %w", err)

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -154,8 +154,9 @@ func (p *USPParser) createRecordData(t *usp.Record) (map[string]any, error) {
 	}
 
 	// Check if request contains the Notify event. (It could be a different event by mistake)
-	if _, ok := payload.Body.GetRequest().GetReqType().(*usp.Request_Notify); !ok {
-		return nil, fmt.Errorf("request does not contain a Notify event")
+	reqType := payload.Body.GetRequest().GetReqType()
+	if _, ok := reqType.(*usp.Request_Notify); !ok {
+		return nil, fmt.Errorf("request does not contain a Notify event, got %T", reqType)
 	}
 
 	jsonMap["event"] = payload.GetBody().GetRequest().GetNotify().GetEvent().GetObjPath()

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -43,6 +43,7 @@ func (p *USPParser) Parse(b []byte) (*skogul.Container, error) {
 
 	if b == nil {
 		atomic.AddUint64(&p.stats.NilData, 1)
+		return nil, errors.New("nil byte slice provided")
 	}
 
 	record, err := p.getUspRecord(b)

--- a/parser/protobuf_usp.go
+++ b/parser/protobuf_usp.go
@@ -40,6 +40,7 @@ func (p *USPParser) initParserStatistics() {
 // Parse accepts a byte slice of protobuf data and marshals it into a container
 func (p *USPParser) Parse(b []byte) (*skogul.Container, error) {
 	p.once.Do(p.initParserStatistics)
+	atomic.AddUint64(&p.stats.Received, 1)
 
 	if b == nil {
 		atomic.AddUint64(&p.stats.NilData, 1)
@@ -86,7 +87,9 @@ func (p *USPParser) Parse(b []byte) (*skogul.Container, error) {
 	container := skogul.Container{}
 	container.Metrics = make([]*skogul.Metric, 1)
 	container.Metrics[0] = &recordMetric
-	return &container, err
+
+	atomic.AddUint64(&p.stats.Parsed, 1)
+	return &container, nil
 }
 
 // getUspRecord Unmarshals []byte into a protoc generated struct and returns it
@@ -161,4 +164,27 @@ func (p *USPParser) createRecordData(t *usp.Record) (map[string]interface{}, err
 	jsonMap["event_data"] = payload.GetBody().GetRequest().GetNotify().GetEvent().GetParams()["Data"]
 
 	return jsonMap, nil
+}
+
+// GetStats prepares a skogul metric with stats for the USP parser.
+func (p *USP_Parser) GetStats() *skogul.Metric {
+	now := skogul.Now()
+	metric := skogul.Metric{
+		Time:     &now,
+		Metadata: make(map[string]interface{}),
+		Data:     make(map[string]interface{}),
+	}
+	metric.Metadata["component"] = "parser"
+	metric.Metadata["type"] = "usp"
+	metric.Metadata["identity"] = skogul.Identity[p]
+
+	p.once.Do(p.initParserStatistics)
+
+	metric.Data["received"] = p.stats.Received
+	metric.Data["parse_errors"] = p.stats.ParseErrors
+	metric.Data["failed_to_json_marshal"] = p.stats.FailedToJsonMarshal
+	metric.Data["failed_to_json_unmarshal"] = p.stats.FailedToJsonUnmarshal
+	metric.Data["nil_data"] = p.stats.NilData
+	metric.Data["parsed"] = p.stats.Parsed
+	return &metric
 }

--- a/parser/protobuf_usp_test.go
+++ b/parser/protobuf_usp_test.go
@@ -84,7 +84,7 @@ func TestUSPExtractJSON(t *testing.T) {
 
 	input := []byte(msgPayload.Body.GetRequest().GetNotify().GetEvent().GetParams()["Data"])
 
-	var k map[string]interface{}
+	var k map[string]any
 
 	if err := json.Unmarshal(input, &k); err != nil {
 		t.Error("Failed to unmarshall json")


### PR DESCRIPTION
The Junos parser was double-counting parsed messages because the Parsed counter was incremented in createData(), which is called within the parsing loop that already tracks successes, while the USP parser had no parsed counter. 

Added various missing defensive checks to ensure not calling methods on nil.

Updated to more modern syntax as recommended by the go lsp, i.e. `interface{}` to `any`, and some other minor cosmetic changes since i was poking around in these files anyway.