### PR TITLE
fix: tests failing from not acquiring port

### DIFF
--- a/sender/net_test.go
+++ b/sender/net_test.go
@@ -39,7 +39,7 @@ func TestTCPLine(t *testing.T) {
   "receivers": {
     "tcpline": {
       "type": "tcp",
-      "address": "localhost:1337",
+      "address": "localhost:2337",
       "handler": "h"
     }
   },
@@ -56,7 +56,7 @@ func TestTCPLine(t *testing.T) {
     },
     "net": {
       "type": "net",
-      "address": "localhost:1337",
+      "address": "localhost:2337",
       "network": "tcp"
     },
     "bad1": {
@@ -81,7 +81,7 @@ func TestTCPLine(t *testing.T) {
     },
     "udp": {
       "type": "net",
-      "address": "localhost:1339",
+      "address": "localhost:2339",
       "network": "udp"
     }
   }


### PR DESCRIPTION
the github CI sometimes randomly (i.e. not related to code changes) fails on tests like this:

```
time="2025-11-28T11:44:14Z" level=info msg="Starting INSECURE http receiver (no TLS)" address="localhost:1339" category=receiver receiver=http
time="2025-11-28T11:44:14Z" level=fatal msg="listen tcp 127.0.0.1:1339: bind: address already in use" category=receiver receiver=http
  FAIL    github.com/telenornms/skogul/sender    1.181s
```

