### PR TITLE
fix: flaking tests due to no free ports in ci

### DIFF
--- a/receiver/http_test.go
+++ b/receiver/http_test.go
@@ -373,6 +373,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	UpdateHttpConfigWithUsablePorts(bConfig)
+
 	rPlain := bConfig.Receivers["plain"].Receiver.(*receiver.HTTP)
 	rSSL := bConfig.Receivers["ssl_auth"].Receiver.(*receiver.HTTP)
 


### PR DESCRIPTION
`TestMain` sometimes fails in CI due to port 1349 being taken, probably due to zombie processes in github's machines. This change adds retries and port incrementing on collision using existing code.