### PR TITLE
feat: support json5 syntax in config files

### DIFF
--- a/config/json5.go
+++ b/config/json5.go
@@ -1,0 +1,56 @@
+/*
+ * skogul, support for JSON5 in configuration files
+ *
+ * Copyright (c) 2026 Telenor Norge AS
+ * Author(s):
+ *  - Aslak Bakkeland <aslak.bakkeland@telenor.no>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package config
+
+import (
+	"github.com/titanous/json5"
+)
+
+// configUnmarshal unmarshals configuration data using JSON5.
+//
+// JSON5 is used for all configuration files because it is a superset of JSON,
+// meaning all valid JSON files parse correctly, but it also support useful
+// (for config files) syntax like comments and trailing commas
+//
+// Note: This is only used for configuration parsing. Data parsing should not
+// use this.
+func configUnmarshal(data []byte, v any) error {
+	return json5.Unmarshal(data, v)
+}
+
+// configSyntaxError attempts to extract position information from a parsing
+// error. Returns the offset if available, or -1 if not.
+func configSyntaxError(err error) (offset int, message string) {
+	if err == nil {
+		return -1, ""
+	}
+
+	// Check if it's a json5.SyntaxError
+	if jerr, ok := err.(*json5.SyntaxError); ok {
+		return int(jerr.Offset), jerr.Error()
+	}
+
+	// For other errors, return -1 to indicate no offset available
+	return -1, err.Error()
+}

--- a/config/parse.go
+++ b/config/parse.go
@@ -103,7 +103,7 @@ func (t *Transformer) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var merged map[string]interface{}
+	var merged map[string]any
 	if err := json.Unmarshal(nest, &merged); err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (t *Transformer) UnmarshalJSON(b []byte) error {
 	}
 
 	// Find superfluous config parameters
-	var jsonConf map[string]interface{}
+	var jsonConf map[string]any
 	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "transformer", t.Type, reflect.ValueOf(t.Transformer).Elem().Type())
 	return nil
@@ -151,7 +151,7 @@ func (r *Receiver) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var merged map[string]interface{}
+	var merged map[string]any
 	if err := json.Unmarshal(nest, &merged); err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (r *Receiver) UnmarshalJSON(b []byte) error {
 	}
 
 	// Find superfluous config parameters
-	var jsonConf map[string]interface{}
+	var jsonConf map[string]any
 	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "receiver", r.Type, reflect.ValueOf(r.Receiver).Elem().Type())
 	return nil
@@ -197,7 +197,7 @@ func (p *Parser) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var merged map[string]interface{}
+	var merged map[string]any
 	if err := json.Unmarshal(nest, &merged); err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (p *Parser) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("parser unmarshalling: %w", err)
 	}
 	// Find superfluous config parameters
-	var jsonConf map[string]interface{}
+	var jsonConf map[string]any
 	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "parser", p.Type, reflect.ValueOf(p.Parser).Elem().Type())
 	return nil
@@ -241,7 +241,7 @@ func (e *Encoder) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var merged map[string]interface{}
+	var merged map[string]any
 	if err := json.Unmarshal(nest, &merged); err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ func (e *Encoder) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("encoder unmarshalling: %w", err)
 	}
 	// Find superfluous config parameters
-	var jsonConf map[string]interface{}
+	var jsonConf map[string]any
 	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "encoder", e.Type, reflect.ValueOf(e.Encoder).Elem().Type())
 	return nil
@@ -285,7 +285,7 @@ func (s *Sender) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var merged map[string]interface{}
+	var merged map[string]any
 	if err := json.Unmarshal(nest, &merged); err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (s *Sender) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("sender unmarshalling: %w", err)
 	}
 	// Find superfluous config parameters
-	var jsonConf map[string]interface{}
+	var jsonConf map[string]any
 	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "sender", s.Type, reflect.ValueOf(s.Sender).Elem().Type())
 	return nil
@@ -394,7 +394,7 @@ func printSyntaxError(b []byte, offset int, text string) {
 // (unfortunately...), then calling secondPass(), which resolves references
 // and does a final validation.
 func Bytes(b []byte) (*Config, error) {
-	var jsonData map[string]interface{}
+	var jsonData map[string]any
 	skogul.HandlerMap = skogul.HandlerMap[0:0]
 	skogul.SenderMap = skogul.SenderMap[0:0]
 	skogul.ParserMap = skogul.ParserMap[0:0]
@@ -661,7 +661,7 @@ func identifyReceivers(c *Config) {
 // secondPass accepts a parsed configuration as input and resolves the
 // references in it, and verifies basic integrity.
 func secondPass(c *Config) (*Config, error) {
-	skogul.Identity = make(map[interface{}]string)
+	skogul.Identity = make(map[any]string)
 	identifyReceivers(c)
 	if err := resolveSenders(c); err != nil {
 		return nil, err
@@ -724,7 +724,7 @@ func secondPass(c *Config) (*Config, error) {
 	return c, nil
 }
 
-func deprecateCheck(family string, name string, item interface{}) {
+func deprecateCheck(family string, name string, item any) {
 	i, ok := item.(skogul.Deprecated)
 	if !ok {
 		return
@@ -736,7 +736,7 @@ func deprecateCheck(family string, name string, item interface{}) {
 
 // verifyItem checks if the item implements Verifier and if so, verifies
 // the item. Otherwise, returns nil.
-func verifyItem(family string, name string, item interface{}) error {
+func verifyItem(family string, name string, item any) error {
 	i, ok := item.(skogul.Verifier)
 	if !ok {
 		confLog.WithFields(logrus.Fields{"family": family, "name": name}).Trace("No verifier found")
@@ -771,22 +771,22 @@ func findFieldsOfStruct(T reflect.Type) []string {
 
 // GetRelevantRawConfigSection is a helper function to dig down into a Config JSON
 // and select the wanted family (receivers, transformers, senders) and item (foo).
-func GetRelevantRawConfigSection(rawConfig *map[string]interface{}, family, section string) map[string]interface{} {
-	configFamily, ok := (*rawConfig)[family].(map[string]interface{})
+func GetRelevantRawConfigSection(rawConfig *map[string]any, family, section string) map[string]any {
+	configFamily, ok := (*rawConfig)[family].(map[string]any)
 	if !ok {
 		confLog.WithFields(logrus.Fields{
 			"family":  family,
 			"section": section,
-		}).Warnf("Failed to cast config family to map[string]interface{}")
+		}).Warnf("Failed to cast config family to map[string]any")
 		return nil
 	}
 
-	configSection, ok := configFamily[section].(map[string]interface{})
+	configSection, ok := configFamily[section].(map[string]any)
 	if !ok {
 		confLog.WithFields(logrus.Fields{
 			"family":  family,
 			"section": section,
-		}).Warnf("Failed to cast config section to map[string]interface{}")
+		}).Warnf("Failed to cast config section to map[string]any")
 		return nil
 	}
 	return configSection
@@ -795,7 +795,7 @@ func GetRelevantRawConfigSection(rawConfig *map[string]interface{}, family, sect
 // VerifyOnlyRequiredConfigProps checks for undefined configuration properties
 // It can be used to identify typos or invalid configuration
 // Use 'config.GetRelevantRawConfigSection' first for handler if you have a full config.
-func VerifyOnlyRequiredConfigProps(componentConfig *map[string]interface{}, family, handler string, T reflect.Type) []string {
+func VerifyOnlyRequiredConfigProps(componentConfig *map[string]any, family, handler string, T reflect.Type) []string {
 	requiredProps := findFieldsOfStruct(T)
 
 	superfluousProperties := make([]string, 0)
@@ -809,7 +809,7 @@ func VerifyOnlyRequiredConfigProps(componentConfig *map[string]interface{}, fami
 		}
 
 		for _, requiredProp := range requiredProps {
-			if strings.ToLower(prop) == strings.ToLower(requiredProp) {
+			if strings.EqualFold(prop, requiredProp) {
 				propertyDefined = true
 				break
 			}

--- a/config/parse.go
+++ b/config/parse.go
@@ -118,7 +118,7 @@ func (t *Transformer) UnmarshalJSON(b []byte) error {
 		Type string
 	}
 	var myt tType
-	if err := json.Unmarshal(b, &myt); err != nil {
+	if err := configUnmarshal(b, &myt); err != nil {
 		return err
 	}
 	t.Type = myt.Type
@@ -131,13 +131,13 @@ func (t *Transformer) UnmarshalJSON(b []byte) error {
 	var ok bool
 	t.Transformer, ok = (transformer.Auto[t.Type].Alloc()).(skogul.Transformer)
 	skogul.Assert(ok)
-	if err := json.Unmarshal(b, &t.Transformer); err != nil {
+	if err := configUnmarshal(b, &t.Transformer); err != nil {
 		return fmt.Errorf("transformer unmarshal: %w", err)
 	}
 
 	// Find superfluous config parameters
 	var jsonConf map[string]interface{}
-	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "transformer", t.Type, reflect.ValueOf(t.Transformer).Elem().Type())
 	return nil
 }
@@ -166,7 +166,7 @@ func (r *Receiver) UnmarshalJSON(b []byte) error {
 		Type string
 	}
 	var t tType
-	if err := json.Unmarshal(b, &t); err != nil {
+	if err := configUnmarshal(b, &t); err != nil {
 		return err
 	}
 	r.Type = t.Type
@@ -179,13 +179,13 @@ func (r *Receiver) UnmarshalJSON(b []byte) error {
 	var ok bool
 	r.Receiver, ok = (receiver.Auto[r.Type].Alloc()).(skogul.Receiver)
 	skogul.Assert(ok)
-	if err := json.Unmarshal(b, &r.Receiver); err != nil {
+	if err := configUnmarshal(b, &r.Receiver); err != nil {
 		return fmt.Errorf("receiver unmarshalling: %w", err)
 	}
 
 	// Find superfluous config parameters
 	var jsonConf map[string]interface{}
-	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "receiver", r.Type, reflect.ValueOf(r.Receiver).Elem().Type())
 	return nil
 }
@@ -211,7 +211,7 @@ func (p *Parser) UnmarshalJSON(b []byte) error {
 		Type string
 	}
 	var t tType
-	if err := json.Unmarshal(b, &t); err != nil {
+	if err := configUnmarshal(b, &t); err != nil {
 		return err
 	}
 	p.Type = t.Type
@@ -224,12 +224,12 @@ func (p *Parser) UnmarshalJSON(b []byte) error {
 	var ok bool
 	p.Parser, ok = (parser.Auto[p.Type].Alloc()).(skogul.Parser)
 	skogul.Assert(ok)
-	if err := json.Unmarshal(b, &p.Parser); err != nil {
+	if err := configUnmarshal(b, &p.Parser); err != nil {
 		return fmt.Errorf("parser unmarshalling: %w", err)
 	}
 	// Find superfluous config parameters
 	var jsonConf map[string]interface{}
-	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "parser", p.Type, reflect.ValueOf(p.Parser).Elem().Type())
 	return nil
 }
@@ -255,7 +255,7 @@ func (e *Encoder) UnmarshalJSON(b []byte) error {
 		Type string
 	}
 	var t tType
-	if err := json.Unmarshal(b, &t); err != nil {
+	if err := configUnmarshal(b, &t); err != nil {
 		return err
 	}
 	e.Type = t.Type
@@ -268,12 +268,12 @@ func (e *Encoder) UnmarshalJSON(b []byte) error {
 	var ok bool
 	e.Encoder, ok = (encoder.Auto[e.Type].Alloc()).(skogul.Encoder)
 	skogul.Assert(ok)
-	if err := json.Unmarshal(b, &e.Encoder); err != nil {
+	if err := configUnmarshal(b, &e.Encoder); err != nil {
 		return fmt.Errorf("encoder unmarshalling: %w", err)
 	}
 	// Find superfluous config parameters
 	var jsonConf map[string]interface{}
-	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "encoder", e.Type, reflect.ValueOf(e.Encoder).Elem().Type())
 	return nil
 }
@@ -299,7 +299,7 @@ func (s *Sender) UnmarshalJSON(b []byte) error {
 		Type string
 	}
 	var t tType
-	if err := json.Unmarshal(b, &t); err != nil {
+	if err := configUnmarshal(b, &t); err != nil {
 		return err
 	}
 	s.Type = t.Type
@@ -312,14 +312,25 @@ func (s *Sender) UnmarshalJSON(b []byte) error {
 	var ok bool
 	s.Sender, ok = (sender.Auto[s.Type].Alloc()).(skogul.Sender)
 	skogul.Assert(ok)
-	if err := json.Unmarshal(b, &s.Sender); err != nil {
+	if err := configUnmarshal(b, &s.Sender); err != nil {
 		return fmt.Errorf("sender unmarshalling: %w", err)
 	}
 	// Find superfluous config parameters
 	var jsonConf map[string]interface{}
-	json.Unmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
+	configUnmarshal(b, &jsonConf) // Assuming this works out well since it did up there ^
 	VerifyOnlyRequiredConfigProps(&jsonConf, "sender", s.Type, reflect.ValueOf(s.Sender).Elem().Type())
 	return nil
+}
+
+// printConfigSyntaxError prints a helpful error message for syntax errors.
+// It attempts to show context around the error location.
+func printConfigSyntaxError(b []byte, err error) {
+	offset, message := configSyntaxError(err)
+	if offset >= 0 {
+		printSyntaxError(b, offset, message)
+	} else {
+		fmt.Printf("Unable to parse configuration.\nError: %s\n", message)
+	}
 }
 
 func printSyntaxError(b []byte, offset int, text string) {
@@ -354,7 +365,7 @@ func printSyntaxError(b []byte, offset int, text string) {
 			lines++
 		}
 	}
-	fmt.Printf("Unable to parse JSON configuration at byte offset %d.\nError: %s\nContext:\n", offset, text)
+	fmt.Printf("Unable to parse configuration at byte offset %d.\nError: %s\nContext:\n", offset, text)
 	fmt.Println(string(b[start:end2]))
 	for i := start2; i < (offset - 2); i++ {
 		if b[i] == '	' {
@@ -372,13 +383,16 @@ func printSyntaxError(b []byte, offset int, text string) {
 	fmt.Println(string(b[end2:end]))
 }
 
-// Bytes parses json in the provided byte array and returns a
-// configuration.
+// Bytes parses the provided byte array as configuration and returns a Config.
 //
-// It does this by first doing a pass where it just does JSON
-// unmarshalling, which also updates sender and handler reference tables
-// globally (unfortunately...), then calling secondPass(), which resolves
-// references and does a final validation.
+// Configuration is parsed using JSON5, which is a superset of JSON supporting
+// comments, trailing commas, and other conveniences. All valid JSON files
+// parse correctly.
+//
+// It does this by first doing a pass where it just does JSON unmarshalling,
+// which also updates sender and handler reference tables globally
+// (unfortunately...), then calling secondPass(), which resolves references
+// and does a final validation.
 func Bytes(b []byte) (*Config, error) {
 	var jsonData map[string]interface{}
 	skogul.HandlerMap = skogul.HandlerMap[0:0]
@@ -386,17 +400,14 @@ func Bytes(b []byte) (*Config, error) {
 	skogul.ParserMap = skogul.ParserMap[0:0]
 	skogul.TransformerMap = skogul.TransformerMap[0:0]
 	skogul.EncoderMap = skogul.EncoderMap[0:0]
-	if err := json.Unmarshal(b, &jsonData); err != nil {
-		jerr, ok := err.(*json.SyntaxError)
-		if ok {
-			printSyntaxError(b, int(jerr.Offset), jerr.Error())
-		}
-		return nil, fmt.Errorf("invalid JSON: %w", err)
+	if err := configUnmarshal(b, &jsonData); err != nil {
+		printConfigSyntaxError(b, err)
+		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	c := Config{}
-	if err := json.Unmarshal(b, &c); err != nil {
-		return nil, fmt.Errorf("valid JSON, but not valid Skogul configuration: %w", err)
+	if err := configUnmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("valid configuration syntax, but not valid Skogul configuration: %w", err)
 	}
 
 	return secondPass(&c)
@@ -417,7 +428,7 @@ func Path(path string) (*Config, error) {
 }
 
 // File opens a config file and parses it, then returns the valid
-// configuration, using Bytes()
+// configuration, using Bytes(). Both .json and .json5 files are supported.
 func File(f string) (*Config, error) {
 	dat, err := os.ReadFile(f)
 	if err != nil {
@@ -426,14 +437,23 @@ func File(f string) (*Config, error) {
 	return Bytes(dat)
 }
 
+// isConfigFile checks if a file has a valid config file extension (.json or .json5)
+func isConfigFile(path string) bool {
+	ext := filepath.Ext(path)
+	return ext == ".json" || ext == ".json5"
+}
+
 func findConfigFiles(path string) ([]string, error) {
 	confLog.WithField("path", path).Debugf("Reading configuration files from %s", path)
 	configFiles := make([]string, 0)
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() && filepath.Ext(path) == ".json" {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && isConfigFile(path) {
 			configFiles = append(configFiles, path)
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -442,8 +462,8 @@ func findConfigFiles(path string) ([]string, error) {
 	return configFiles, nil
 }
 
-// ReadFiles reads all JSON files (with the .JSON suffix) in a given directory
-// and combines them to a configuration for the program.
+// ReadFiles reads all config files (with .json or .json5 suffix) in a
+// given directory and combines them to a configuration for the program.
 func ReadFiles(p string) (*Config, error) {
 	files, err := findConfigFiles(p)
 	if err != nil {
@@ -459,12 +479,9 @@ func ReadFiles(p string) (*Config, error) {
 			return nil, err
 		}
 
-		err = json.Unmarshal(b, &config)
+		err = configUnmarshal(b, &config)
 		if err != nil {
-			jerr, ok := err.(*json.SyntaxError)
-			if ok {
-				printSyntaxError(b, int(jerr.Offset), jerr.Error())
-			}
+			printConfigSyntaxError(b, err)
 			return nil, err
 		}
 	}

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -37,7 +37,7 @@ import (
 func TestFile(t *testing.T) {
 	defer func() {
 		if skogul.AssertErrors > 0 {
-			t.Errorf("File() paniced")
+			t.Errorf("File() panicked")
 		}
 	}()
 	c, err := config.File("testdata/test.json")
@@ -49,10 +49,40 @@ func TestFile(t *testing.T) {
 	}
 }
 
+func TestJSON5File(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("File() panicked")
+		}
+	}()
+
+	c, err := config.File("testdata/test.json5")
+	if err != nil {
+		t.Fatalf("File() failed with .json5 file: %v", err)
+	}
+	if c == nil {
+		t.Fatal("File() returned nil config for .json5 file")
+	}
+
+	if c.Handlers == nil {
+		t.Fatal("Handlers map is nil")
+	}
+	if h, ok := c.Handlers["plain"]; !ok || h == nil {
+		t.Error("Handler 'plain' not found or nil in parsed .json5 config")
+	}
+
+	if c.Receivers == nil {
+		t.Fatal("Receivers map is nil")
+	}
+	if r, ok := c.Receivers["http"]; !ok || r == nil {
+		t.Error("Receiver 'http' not found or nil in parsed .json5 config")
+	}
+}
+
 func TestByte_ok(t *testing.T) {
 	defer func() {
 		if skogul.AssertErrors > 0 {
-			t.Errorf("Byte() paniced")
+			t.Errorf("Bytes() panicked")
 		}
 	}()
 	okData := []byte(`
@@ -138,7 +168,7 @@ func TestByte_ok(t *testing.T) {
 func TestDefaultModules(t *testing.T) {
 	defer func() {
 		if skogul.AssertErrors > 0 {
-			t.Errorf("Byte() paniced")
+			t.Errorf("Bytes() panicked")
 		}
 	}()
 	okData := []byte(`
@@ -172,7 +202,7 @@ func TestDefaultModules(t *testing.T) {
 func TestUndefinedParser(t *testing.T) {
 	defer func() {
 		if skogul.AssertErrors > 0 {
-			t.Errorf("Byte() paniced")
+			t.Errorf("Bytes() panicked")
 		}
 	}()
 	okData := []byte(`
@@ -203,7 +233,7 @@ func TestUndefinedParser(t *testing.T) {
 func TestNamedParser(t *testing.T) {
 	defer func() {
 		if skogul.AssertErrors > 0 {
-			t.Errorf("Byte() paniced")
+			t.Errorf("Bytes() panicked")
 		}
 	}()
 	okData := []byte(`
@@ -584,3 +614,158 @@ func TestReadConfigFiles(t *testing.T) {
 		t.Error("Missing a receiver which should be configured")
 	}
 }
+
+// TestStrictJSONCompatibility verifies that strict JSON (without JSON5
+// features like comments or trailing commas) continues to parse correctly.
+func TestStrictJSONCompatibility(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("Bytes() panicked")
+		}
+	}()
+
+	// Strict JSON with no trailing commas or comments
+	strictJSON := []byte(`{
+  "handlers": {
+    "plain": {
+      "parser": "skogul",
+      "sender": "debug",
+      "transformers": []
+    }
+  },
+  "receivers": {
+    "http": {
+      "type": "http",
+      "handlers": {
+        "/": "plain"
+      }
+    }
+  }
+}`)
+
+	c, err := config.Bytes(strictJSON)
+	if err != nil {
+		t.Fatalf("Bytes() failed with strict JSON: %v", err)
+	}
+	if c == nil {
+		t.Fatal("Bytes() returned nil config for strict JSON")
+	}
+
+	if c.Handlers == nil || c.Handlers["plain"] == nil {
+		t.Error("Handler 'plain' not found in parsed strict JSON config")
+	}
+	if c.Receivers == nil || c.Receivers["http"] == nil {
+		t.Error("Receiver 'http' not found in parsed strict JSON config")
+	}
+}
+
+func TestJSON5Combined(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("Bytes() panicked")
+		}
+	}()
+
+	// Config with comments and trailing commas
+	json5Data := []byte(`
+{
+  // Main handlers configuration
+  "handlers": {
+    "plain": {
+      "parser": "skogul",
+      "sender": "debug",
+      "transformers": [], // empty transformers
+    },
+  },
+  /* Receivers section
+     configures HTTP endpoint */
+  "receivers": {
+    "http": {
+      "type": "http",
+      "handlers": {
+        "/": "plain",
+      },
+    },
+  },
+}
+`)
+
+	c, err := config.Bytes(json5Data)
+	if err != nil {
+		t.Fatalf("Bytes() failed with combined JSON5 features: %v", err)
+	}
+	if c == nil {
+		t.Fatal("Bytes() returned nil config for JSON5 with combined features")
+	}
+
+	// Handlers
+	if c.Handlers == nil {
+		t.Fatal("Handlers map is nil")
+	}
+	if h, ok := c.Handlers["plain"]; !ok || h == nil {
+		t.Error("Handler 'plain' not found or nil in parsed config")
+	}
+
+	// Receivers
+	if c.Receivers == nil {
+		t.Fatal("Receivers map is nil")
+	}
+	if r, ok := c.Receivers["http"]; !ok || r == nil {
+		t.Error("Receiver 'http' not found or nil in parsed config")
+	}
+}
+
+func TestJSON5InvalidSyntax(t *testing.T) {
+	defer func() {
+		if skogul.AssertErrors > 0 {
+			t.Errorf("Bytes() panicked")
+		}
+	}()
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "unclosed comment",
+			data: []byte(`{
+  "handlers": {},
+  /* this comment is never closed
+}`),
+		},
+		{
+			name: "invalid trailing content",
+			data: []byte(`{
+  "handlers": {}
+} extra content`),
+		},
+		{
+			name: "missing colon",
+			data: []byte(`{
+  "handlers" {}
+}`),
+		},
+		{
+			name: "unclosed braces",
+			data: []byte(`{
+  "handlers": {
+    "plain": {
+      "parser": "skogul"
+    }
+}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := config.Bytes(tt.data)
+			if err == nil {
+				t.Errorf("Bytes() should have failed for %s, but returned config: %+v", tt.name, c)
+			}
+			if c != nil {
+				t.Errorf("Bytes() should return nil config for invalid syntax")
+			}
+		})
+	}
+}
+

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -491,7 +491,7 @@ func TestFindSuperfluousReceiverConfigPropertiesFromFullConfig(t *testing.T) {
 	  }
 	}`)
 
-	var parsedConfig map[string]interface{}
+	var parsedConfig map[string]any
 	err := json.Unmarshal(rawConfig, &parsedConfig)
 
 	relevantConfig := config.GetRelevantRawConfigSection(&parsedConfig, "receivers", "foo")
@@ -500,7 +500,7 @@ func TestFindSuperfluousReceiverConfigPropertiesFromFullConfig(t *testing.T) {
 		t.Error("Failed to parse config")
 	}
 
-	configStruct := reflect.TypeOf(receiver.UDP{})
+	configStruct := reflect.TypeFor[receiver.UDP]()
 	superfluousProperties := config.VerifyOnlyRequiredConfigProps(&relevantConfig, "receivers", "foo", configStruct)
 
 	if len(superfluousProperties) != 1 {
@@ -520,13 +520,13 @@ func TestFindSuperfluousReceiverConfigProperties(t *testing.T) {
 		"superfluousField": "this is not needed"
 	}`)
 
-	var c map[string]interface{}
+	var c map[string]any
 	err := json.Unmarshal(rawConfig, &c)
 	if err != nil {
 		t.Error("Failed to parse config")
 	}
 
-	configStruct := reflect.TypeOf(receiver.UDP{})
+	configStruct := reflect.TypeFor[receiver.UDP]()
 	superfluousProperties := config.VerifyOnlyRequiredConfigProps(&c, "receivers", "foo", configStruct)
 
 	if len(superfluousProperties) != 1 {
@@ -578,7 +578,7 @@ func TestReadConfigWithoutSuperfluousParamsNoSuperfluousParams(t *testing.T) {
     }
   }`)
 
-	var c map[string]interface{}
+	var c map[string]any
 	err := json.Unmarshal(rawConfig, &c)
 	if err != nil {
 		t.Errorf("Failed to unmarshal json: %s", err)
@@ -586,11 +586,11 @@ func TestReadConfigWithoutSuperfluousParamsNoSuperfluousParams(t *testing.T) {
 
 	superfluousProperties := make([]string, 0)
 
-	configStruct := reflect.TypeOf(receiver.Stdin{})
+	configStruct := reflect.TypeFor[receiver.Stdin]()
 	c1 := config.GetRelevantRawConfigSection(&c, "receivers", "foo")
 	superfluousProperties = append(superfluousProperties, config.VerifyOnlyRequiredConfigProps(&c1, "receiver", "foo", configStruct)...)
 
-	configStruct = reflect.TypeOf(sender.Debug{})
+	configStruct = reflect.TypeFor[sender.Debug]()
 	c2 := config.GetRelevantRawConfigSection(&c, "senders", "baz")
 	superfluousProperties = append(superfluousProperties, config.VerifyOnlyRequiredConfigProps(&c2, "sender", "baz", configStruct)...)
 
@@ -768,4 +768,3 @@ func TestJSON5InvalidSyntax(t *testing.T) {
 		})
 	}
 }
-

--- a/config/testdata/test.json5
+++ b/config/testdata/test.json5
@@ -1,0 +1,25 @@
+{
+  // This is a JSON5 config file with comments and trailing commas
+  "senders": {
+    "debug": {
+      "type": "debug",
+    },
+  },
+  "handlers": {
+    /* Multi-line comment:
+       This handler uses the debug sender */
+    "plain": {
+      "parser": "skogul",
+      "sender": "debug",
+      "transformers": [], // empty transformers
+    },
+  },
+  "receivers": {
+    "http": {
+      "type": "http",
+      "handlers": {
+        "/": "plain",
+      },
+    },
+  },
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/nats-io/nats.go v1.35.0
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10
 	github.com/rabbitmq/amqp091-go v1.10.0
+	github.com/titanous/json5 v1.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
 github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -49,6 +51,8 @@ github.com/prometheus/common v0.54.0 h1:ZlZy0BgJhTwVZUn7dLOkwCZHUkrAqd3WYtcFCWnM
 github.com/prometheus/common v0.54.0/go.mod h1:/TQgMJP5CuVYveyT7n/0Ix8yLNNXy9yRSkhnLTHPDIQ=
 github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/robertkrimen/otto v0.2.1 h1:FVP0PJ0AHIjC+N4pKCG9yCDz6LHNPCwi/GKID5pGGF0=
+github.com/robertkrimen/otto v0.2.1/go.mod h1:UPwtJ1Xu7JrLcZjNWN8orJaM5n5YEtqL//farB5FlRY=
 github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
@@ -61,6 +65,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/titanous/json5 v1.0.0 h1:hJf8Su1d9NuI/ffpxgxQfxh/UiBFZX7bMPid0rIL/7s=
+github.com/titanous/json5 v1.0.0/go.mod h1:7JH1M8/LHKc6cyP5o5g3CSaRj+mBrIimTxzpvmckH8c=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=
@@ -123,6 +129,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
+gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/testdata/invalid_configs/json_unmarshal/2.json
+++ b/testdata/invalid_configs/json_unmarshal/2.json
@@ -1,4 +1,4 @@
 {
 	"some": "json",
-	false: 5
+	"key":
 }


### PR DESCRIPTION
Since config files are only read in at startup, adding support for comments and trailing commas and certain other niceties in those files will help users working with complex config files. See https://json5.org for the specifics of the json5 spec used here. Implemented using https://github.com/titanous/json5 as this one was the fastest and most maintained package implementing the spec in my benchmarking. 