### PR TITLE
fix: revert build base to use rockylinux 7 to support centos 7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     container:
-      image: rockylinux:9
+      image: rockylinux:8
       env:
         GIT_DESCRIBE: ${{ github.ref_name }}
     steps:
@@ -19,7 +19,7 @@ jobs:
           cache: true
       - name: Test
         run: |
-          yum install -y git python3-docutils rpm-build wget make gcc coreutils-single systemd
+          yum install -y git python3-docutils rpm-build wget make gcc coreutils-single
           make check
       - name: Build tarball
         id: build

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM rockylinux:8
 ENV SHELL bash
 RUN yum install -y vim man
 RUN yum install -y git python3-docutils rpm-build wget make

--- a/build/Dockerfile.rpm-make-check
+++ b/build/Dockerfile.rpm-make-check
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM rockylinux:8
 ENV SHELL=/bin/bash
 RUN yum install -y git python3-docutils rpm-build wget make gcc
 RUN wget https://storage.googleapis.com/golang/getgo/installer_linux

--- a/build/redhat-skogul.spec.in
+++ b/build/redhat-skogul.spec.in
@@ -13,7 +13,7 @@ BuildArch:      xxARCHxx
 # Since we download go manually and not through yum,
 # the version won't be registered as installed.
 #BuildRequires:  go >= 1.13
-BuildRequires:  python3-docutils, systemd
+BuildRequires:  python3-docutils, systemd-units
 
 
 %description

--- a/docs/NEWS
+++ b/docs/NEWS
@@ -1,3 +1,10 @@
+v0.32.1
+=======
+
+Downgrade build OS in Dockerfile from Rockylinux 9 to 8 to support users still
+on CentOS 7
+
+
 v0.32.0
 =======
 


### PR DESCRIPTION
Some users are still on CentOS 7 and could not install the new rpm.