### PR TITLE
feat: add action prefix to mnr sender

### DIFF
--- a/sender/mnr.go
+++ b/sender/mnr.go
@@ -1,7 +1,7 @@
 /*
  * skogul, M&R port collector sender
  *
- * Copyright (c) 2019 Telenor Norge AS
+ * Copyright (c) 2019-2026 Telenor Norge AS
  * Author(s):
  *  - Kristian Lyngstøl <kly@kly.no>
  *
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/telenornms/skogul"
 )
@@ -38,7 +39,7 @@ MnR sender writes to M&R port collector.
 
 The output format is:
 
-	<timestamp>\t<groupname>\t<variable>\t<value>(\t<property>=<value>)*
+	<optional-action-flag>\t<timestamp>\t<groupname>\t<variable>\t<value>(\t<property>=<value>)*
 
 Example:
 
@@ -50,26 +51,26 @@ and "prefix" will be used to prefix all individual data variables.
 E.g:
 
 	{
-	    "template": {
-		    "timestamp": "2019-03-15T11:08:02+01:00",
-		    "metadata": {
+			"template": {
+				"timestamp": "2019-03-15T11:08:02+01:00",
+				"metadata": {
 			"server": "somewhere.example.com"
-		    }
-	    },
-	    "metrics": [
+				}
+			},
+			"metrics": [
 		{
-		    "metadata": {
+				"metadata": {
 			"prefix": "myDevice.",
 			"key": "value",
 			"paramkey": "paramvalue"
-		    },
-		    "data": {
+				},
+				"data": {
 			"astring": "text",
 			"float": 1.11,
 			"integer": 5
-		    }
+				}
 		}
-	    ]
+			]
 	}
 
 Will result in:
@@ -88,6 +89,21 @@ default group is "group". Meaning:
 type MnR struct {
 	Address      string `doc:"Address to send data to" example:"192.168.1.99:1234"`
 	DefaultGroup string `doc:"Default group to use if the metadatafield group is missing."`
+	Action       string `doc:"Optional action flag to prepend to each line. Valid values are 'refresh' and 'delete'."`
+}
+
+// Verify checks the configuration of the MnR sender.
+func (mnr *MnR) Verify() error {
+	if mnr.Address == "" {
+		return skogul.MissingArgument("Address")
+	}
+	if mnr.Action != "" {
+		action := strings.ToLower(mnr.Action)
+		if action != "refresh" && action != "delete" {
+			return fmt.Errorf("invalid action %q: must be 'refresh' or 'delete'", mnr.Action)
+		}
+	}
+	return nil
 }
 
 /*
@@ -107,18 +123,25 @@ func (mnr *MnR) Send(c *skogul.Container) error {
 	if err != nil {
 		return fmt.Errorf("unable to connect to MnR at %s: %w", mnr.Address, err)
 	}
+	actionPrefix := ""
+	switch strings.ToLower(mnr.Action) {
+	case "refresh":
+		actionPrefix = "+r\t"
+	case "delete":
+		actionPrefix = "+d\t"
+	}
+
 	for _, m := range c.Metrics {
 		var bufferpre bytes.Buffer
 		var bufferpost bytes.Buffer
-		fmt.Fprintf(&bufferpre, "%d\t", m.Time.Unix())
-		if m.Metadata["group"] == nil {
-			if mnr.DefaultGroup == "" {
-				fmt.Fprintf(&bufferpre, "group\t")
-			} else {
-				fmt.Fprintf(&bufferpre, "%s\t", mnr.DefaultGroup)
-			}
-		} else {
+		fmt.Fprintf(&bufferpre, "%s%d\t", actionPrefix, m.Time.Unix())
+		switch {
+		case m.Metadata["group"] != nil:
 			fmt.Fprintf(&bufferpre, "%s\t", m.Metadata["group"])
+		case mnr.DefaultGroup != "":
+			fmt.Fprintf(&bufferpre, "%s\t", mnr.DefaultGroup)
+		default:
+			fmt.Fprintf(&bufferpre, "group\t")
 		}
 		pre := ""
 		if m.Metadata["prefix"] != nil {

--- a/sender/mnr_test.go
+++ b/sender/mnr_test.go
@@ -1,0 +1,237 @@
+/*
+ * skogul, M&R sender tests
+ *
+ * Copyright (c) 2026 Telenor Norge AS
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ */
+
+package sender_test
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/telenornms/skogul"
+	"github.com/telenornms/skogul/sender"
+)
+
+// startTCPListener starts a TCP listener on a random port and returns
+// the listener and the received data after one connection.
+func startTCPListener(t *testing.T) (net.Listener, int, chan string) {
+	t.Helper()
+	port := 10000 + rand.Intn(10000)
+	ln, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		t.Fatalf("Failed to start TCP listener: %v", err)
+	}
+	ch := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4096)
+		n, _ := conn.Read(buf)
+		ch <- string(buf[:n])
+	}()
+	return ln, port, ch
+}
+
+func TestMnR_Verify(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		action  string
+		wantErr bool
+	}{
+		{"missing address", "", "", true},
+		{"empty action is valid", "localhost:1234", "", false},
+		{"refresh is valid", "localhost:1234", "refresh", false},
+		{"delete is valid", "localhost:1234", "delete", false},
+		{"Refresh is valid", "localhost:1234", "Refresh", false},
+		{"DELETE is valid", "localhost:1234", "DELETE", false},
+		{"invalid action", "localhost:1234", "bogus", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mnr := &sender.MnR{
+				Address: tt.address,
+				Action:  tt.action,
+			}
+			err := mnr.Verify()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMnR_Send(t *testing.T) {
+	ln, port, ch := startTCPListener(t)
+	defer ln.Close()
+
+	now := time.Now()
+	m := skogul.Metric{
+		Time:     &now,
+		Metadata: map[string]any{"group": "testgroup", "prefix": "dev."},
+		Data:     map[string]any{"cpu": 42},
+	}
+	c := skogul.Container{Metrics: []*skogul.Metric{&m}}
+
+	mnr := &sender.MnR{
+		Address: fmt.Sprintf("localhost:%d", port),
+	}
+	err := mnr.Send(&c)
+	if err != nil {
+		t.Fatalf("Send() returned error: %v", err)
+	}
+
+	received := <-ch
+	if !strings.Contains(received, "testgroup") {
+		t.Errorf("Expected 'testgroup' in output, got: %s", received)
+	}
+	if !strings.Contains(received, "dev.cpu") {
+		t.Errorf("Expected 'dev.cpu' in output, got: %s", received)
+	}
+	if !strings.HasPrefix(received, fmt.Sprintf("%d\t", now.Unix())) {
+		t.Errorf("Expected line to start with timestamp, got: %s", received)
+	}
+}
+
+func TestMnR_SendDefaultGroup(t *testing.T) {
+	ln, port, ch := startTCPListener(t)
+	defer ln.Close()
+
+	now := time.Now()
+	m := skogul.Metric{
+		Time:     &now,
+		Metadata: map[string]any{},
+		Data:     map[string]any{"val": 1},
+	}
+	c := skogul.Container{Metrics: []*skogul.Metric{&m}}
+
+	mnr := &sender.MnR{
+		Address:      fmt.Sprintf("localhost:%d", port),
+		DefaultGroup: "mygroup",
+	}
+	err := mnr.Send(&c)
+	if err != nil {
+		t.Fatalf("Send() returned error: %v", err)
+	}
+
+	received := <-ch
+	if !strings.Contains(received, "mygroup") {
+		t.Errorf("Expected 'mygroup' in output, got: %s", received)
+	}
+}
+
+func TestMnR_SendFallbackGroup(t *testing.T) {
+	ln, port, ch := startTCPListener(t)
+	defer ln.Close()
+
+	now := time.Now()
+	m := skogul.Metric{
+		Time:     &now,
+		Metadata: map[string]any{},
+		Data:     map[string]any{"val": 1},
+	}
+	c := skogul.Container{Metrics: []*skogul.Metric{&m}}
+
+	mnr := &sender.MnR{
+		Address: fmt.Sprintf("localhost:%d", port),
+	}
+	err := mnr.Send(&c)
+	if err != nil {
+		t.Fatalf("Send() returned error: %v", err)
+	}
+
+	received := <-ch
+	if !strings.Contains(received, "\tgroup\t") {
+		t.Errorf("Expected fallback 'group' in output, got: %s", received)
+	}
+}
+
+func TestMnR_SendActionRefresh(t *testing.T) {
+	ln, port, ch := startTCPListener(t)
+	defer ln.Close()
+
+	now := time.Now()
+	m := skogul.Metric{
+		Time:     &now,
+		Metadata: map[string]any{},
+		Data:     map[string]any{"val": 1},
+	}
+	c := skogul.Container{Metrics: []*skogul.Metric{&m}}
+
+	mnr := &sender.MnR{
+		Address: fmt.Sprintf("localhost:%d", port),
+		Action:  "refresh",
+	}
+	err := mnr.Send(&c)
+	if err != nil {
+		t.Fatalf("Send() returned error: %v", err)
+	}
+
+	received := <-ch
+	if !strings.HasPrefix(received, "+r\t") {
+		t.Errorf("Expected line to start with '+r\\t', got: %s", received)
+	}
+}
+
+func TestMnR_SendActionDelete(t *testing.T) {
+	ln, port, ch := startTCPListener(t)
+	defer ln.Close()
+
+	now := time.Now()
+	m := skogul.Metric{
+		Time:     &now,
+		Metadata: map[string]any{},
+		Data:     map[string]any{"val": 1},
+	}
+	c := skogul.Container{Metrics: []*skogul.Metric{&m}}
+
+	mnr := &sender.MnR{
+		Address: fmt.Sprintf("localhost:%d", port),
+		Action:  "delete",
+	}
+	err := mnr.Send(&c)
+	if err != nil {
+		t.Fatalf("Send() returned error: %v", err)
+	}
+
+	received := <-ch
+	if !strings.HasPrefix(received, "+d\t") {
+		t.Errorf("Expected line to start with '+d\\t', got: %s", received)
+	}
+}
+
+func TestMnR_SendBadAddress(t *testing.T) {
+	mnr := &sender.MnR{
+		Address: "localhost:1",
+	}
+	c := skogul.Container{Metrics: []*skogul.Metric{}}
+	err := mnr.Send(&c)
+	if err == nil {
+		t.Error("Expected error when sending to bad address, got nil")
+	}
+}


### PR DESCRIPTION
Add support for the `refresh` and `delete` actions of M&R to the `mnr sender`.