### PR TITLE
fix: race in timer.go

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -30,10 +30,10 @@ import (
 
 const syncPeriod = time.Millisecond * 100
 
-var ltime struct {
-	sec  int64
-	nsec int64
-}
+// ltime holds the cached time as nanoseconds since the Unix epoch. A single
+// int64 is used (rather than separate sec/nsec fields) so that reads and
+// writes are atomic and can never tear across the two values.
+var ltime atomic.Int64
 
 func init() {
 	go syncTime()
@@ -41,11 +41,7 @@ func init() {
 
 func syncTime() {
 	f := func() {
-		t := time.Now()
-		s := int64(t.Unix())
-		ns := int64(t.Nanosecond())
-		atomic.StoreInt64(&ltime.sec, s)
-		atomic.StoreInt64(&ltime.nsec, ns)
+		ltime.Store(time.Now().UnixNano())
 	}
 	f()
 	myticker := time.NewTicker(syncPeriod)
@@ -70,5 +66,5 @@ configurable. The primary use case here is for transformers or parsers that
 need to insert time, but might get thousands of metrics per second.
 */
 func Now() time.Time {
-	return time.Unix(ltime.sec, ltime.nsec)
+	return time.Unix(0, ltime.Load())
 }


### PR DESCRIPTION
Fixes race condition in `skogul.Now()`

```
❯ go test -race
[...]
==================
==================
WARNING: DATA RACE
Read at 0x000107001058 by goroutine 39:
  github.com/telenornms/skogul.Now()
      /tmp/skogul/timer.go:73 +0x2d0
  github.com/telenornms/skogul_test.TestNow()
      /tmp/skogul/timer_test.go:50 +0x2ac
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.0/libexec/src/testing/testing.go:2101 +0x34

Previous write at 0x000107001058 by goroutine 19:
  ??()
      -:0 +0x10272265c
  sync/atomic.StoreInt64()
      <autogenerated>:1 +0x10
  github.com/telenornms/skogul.syncTime()
      /tmp/skogul/timer.go:55 +0x6c
```